### PR TITLE
fix(FEC-7076, FEC-7075, FEC-7036): ios, companions and overlay ad issues

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -150,10 +150,10 @@ function onAdLoaded(options: Object, adEvent: any): void {
  */
 function onAdStarted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  let ad = adEvent.getAd();
+  this._currentAd = adEvent.getAd();
   this._resizeAd();
-  this._maybeDisplayCompanionAds(ad);
-  if (!ad.isLinear()) {
+  this._maybeDisplayCompanionAds();
+  if (!this._currentAd.isLinear()) {
     this._setVideoEndedCallbackEnabled(true);
     if (this._nextPromise) {
       this._resolveNextPromise();
@@ -205,10 +205,10 @@ function onAdPaused(options: Object, adEvent: any): void {
  */
 function onAdCompleted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  let ad = adEvent.getAd();
-  if (ad.isLinear()) {
+  if (this._currentAd.isLinear()) {
     this._stopAdInterval();
   }
+  this._currentAd = null;
   this.dispatchEvent(options.transition);
 }
 


### PR DESCRIPTION
### Description of the Changes

Bug fixes:
* Content video never started on iOS .
* FEC-7076 - [Win10][Player_V3][HLS][IMA] - When playing html5 player there is only audio
* FEC-7075 - [Win10][Player_V3][HLS][IMA] - In audio track the overlay ad is displayed after replay
* FEC-7036 - Player V3:IMA: DFP auto companions is not working (black screen with audio after clicking play)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
