### PR TITLE
fix(FEC-7058): align ad video tag to the left

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -139,6 +139,7 @@ export default class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
+  this._alignAdVideoElement();
   this.dispatchEvent(options.transition, normalizeAdEvent(adEvent));
 }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -677,6 +677,21 @@ export default class Ima extends BasePlugin {
   }
 
   /**
+   * Align the ad video tag.
+   * Fix for FEC-7058.
+   * @private
+   * @returns {void}
+   */
+  _alignAdVideoElement(): void {
+    if (!this._adsManager.isCustomPlaybackUsed()) {
+      let adVideoElement = this._adsContainerDiv.getElementsByTagName('video')[0];
+      if (adVideoElement) {
+        adVideoElement.style.left = '0px';
+      }
+    }
+  }
+
+  /**
    * Resolves the next promise to let the next handler in the middleware chain start.
    * @private
    * @returns {void}


### PR DESCRIPTION
### Description of the Changes

On Android devices the screen is splitted and we need to align to the left the ad video element.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
