### PR TITLE
fix(FEC-7108, FEC-7057): preload content player right after user gesture

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -164,7 +164,6 @@ function onAdStarted(options: Object, adEvent: any): void {
     this._startAdInterval();
   }
   this.dispatchEvent(options.transition);
-  this._maybePreloadContent();
 }
 
 /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -288,6 +288,7 @@ export default class Ima extends BasePlugin {
       this.logger.debug("Initial user action");
       this._nextPromise = Utils.Object.defer();
       this._adDisplayContainer.initialize();
+      this.player.load();
       this._startAdsManager();
     } catch (adError) {
       this.logger.error(adError);
@@ -303,21 +304,9 @@ export default class Ima extends BasePlugin {
    */
   _startAdsManager(): void {
     let playerViewSize = this._getPlayerViewSize();
-    if (this._adsManager.isCustomPlaybackUsed()) {
-      this.logger.debug("Waiting for loadedmetada event");
-      this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, () => {
-        this.logger.debug("Loadedmetada event raised: start ads manager");
-        this.eventManager.unlisten(this.player, this.player.Event.LOADED_METADATA);
-        this._adsManager.init(playerViewSize.width, playerViewSize.height, this._sdk.ViewMode.NORMAL);
-        this._adsManager.start();
-      });
-      this.logger.debug("Load player");
-      this.player.load();
-    } else {
-      this.logger.debug("Start ads manager");
-      this._adsManager.init(playerViewSize.width, playerViewSize.height, this._sdk.ViewMode.NORMAL);
-      this._adsManager.start();
-    }
+    this.logger.debug("Start ads manager");
+    this._adsManager.init(playerViewSize.width, playerViewSize.height, this._sdk.ViewMode.NORMAL);
+    this._adsManager.start();
   }
 
   /**
@@ -661,18 +650,6 @@ export default class Ima extends BasePlugin {
     if (this._intervalTimer) {
       clearInterval(this._intervalTimer);
       this._intervalTimer = null;
-    }
-  }
-
-  /**
-   * Maybe pre loaded the player.
-   * @private
-   * @returns {void}
-   */
-  _maybePreloadContent(): void {
-    if (!this.player.src && !this._adsManager.isCustomPlaybackUsed()) {
-      this.logger.debug("Preloading content");
-      this.player.load();
     }
   }
 

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -146,7 +146,7 @@ describe('Ima Plugin', function () {
     player.addEventListener(player.Event.AD_STARTED, () => {
       maybeDoneTest(cuePoints, adPodIndex, done);
     });
-    player.addEventListener(player.Event.FIRST_PLAY, () => {
+    player.addEventListener(player.Event.LOADED_METADATA, () => {
       player.currentTime = player.duration - 1;
     });
     player.play();
@@ -164,7 +164,7 @@ describe('Ima Plugin', function () {
     player.addEventListener(player.Event.AD_STARTED, () => {
       maybeDoneTest(cuePoints, adPodIndex, done);
     });
-    player.addEventListener(player.Event.FIRST_PLAY, () => {
+    player.addEventListener(player.Event.LOADED_METADATA, () => {
       player.currentTime = player.duration - 1;
     });
     player.play();
@@ -182,7 +182,7 @@ describe('Ima Plugin', function () {
     player.addEventListener(player.Event.AD_STARTED, () => {
       maybeDoneTest(cuePoints, adPodIndex, done);
     });
-    player.addEventListener(player.Event.FIRST_PLAY, () => {
+    player.addEventListener(player.Event.LOADED_METADATA, () => {
       player.currentTime = player.duration - 1;
     });
     player.play();


### PR DESCRIPTION
### Description of the Changes

Move to preload content player action to be soon as possible (right after user gesture).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
