### PR TITLE
fix(FEC-7108): native load on mobile devices

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -288,13 +288,26 @@ export default class Ima extends BasePlugin {
       this.logger.debug("Initial user action");
       this._nextPromise = Utils.Object.defer();
       this._adDisplayContainer.initialize();
-      this.player.load();
+      this._loadContentPlayer();
       this._startAdsManager();
     } catch (adError) {
       this.logger.error(adError);
       this.destroy();
     }
     return this._nextPromise;
+  }
+
+  /**
+   * Loads content player on user gesture.
+   * @private
+   * @returns {void}
+   */
+  _loadContentPlayer(): void {
+    this.logger.debug("Loads content player");
+    this.player.load();
+    if (this.player.env.device.type === "mobile" && !this._adsManager.isCustomPlaybackUsed()) {
+      this.player.getVideoElement().load();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

On mobile devices without custom playback (2 video tags) - we should native load the 
content video element on user gesture to avoid error on Chrome. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
