### PR TITLE
fix(FEC-7135):  fullscreen fix for overlay ad on safari

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -317,8 +317,12 @@ export default class Ima extends BasePlugin {
    * @returns {void}
    */
   _addBindings(): void {
+    [
+      'fullscreenchange',
+      'mozfullscreenchange',
+      'webkitfullscreenchange'
+    ].forEach((fullScreenEvent) => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this), false));
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
-    this.eventManager.listen(this.player.getVideoElement(), 'resize', this._resizeAd.bind(this));
     this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, this._onLoadedMetadata.bind(this));
     this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._onMediaTimeUpdate.bind(this));
     this.eventManager.listen(this.player, this.player.Event.SEEKING, this._onMediaSeeking.bind(this));
@@ -427,8 +431,22 @@ export default class Ima extends BasePlugin {
   _resizeAd() {
     if (this._sdk && this._adsManager) {
       let playerViewSize = this._getPlayerViewSize();
-      this._adsManager.resize(playerViewSize.width, playerViewSize.height, this._sdk.ViewMode.NORMAL);
+      let isFullScreen = this._isFullScreen();
+      let viewMode = (isFullScreen ? this._sdk.ViewMode.FULLSCREEN : this._sdk.ViewMode.NORMAL);
+      this._adsManager.resize(playerViewSize.width, playerViewSize.height, viewMode);
     }
+  }
+
+  /**
+   * Helper for checking if the document is in full screen mode.
+   * @private
+   * @returns {boolean} - Whether the document is in full screen mode.
+   */
+  _isFullScreen(): boolean {
+    return typeof document.fullscreenElement !== 'undefined' && Boolean(document.fullscreenElement) ||
+      typeof document.webkitFullscreenElement !== 'undefined' && Boolean(document.webkitFullscreenElement) ||
+      typeof document.mozFullScreenElement !== 'undefined' && Boolean(document.mozFullScreenElement) ||
+      typeof document.msFullscreenElement !== 'undefined' && Boolean(document.msFullscreenElement);
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -321,7 +321,7 @@ export default class Ima extends BasePlugin {
       'fullscreenchange',
       'mozfullscreenchange',
       'webkitfullscreenchange'
-    ].forEach((fullScreenEvent) => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this), false));
+    ].forEach((fullScreenEvent) => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this)));
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
     this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, this._onLoadedMetadata.bind(this));
     this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._onMediaTimeUpdate.bind(this));

--- a/src/ima.js
+++ b/src/ima.js
@@ -321,7 +321,8 @@ export default class Ima extends BasePlugin {
       'fullscreenchange',
       'mozfullscreenchange',
       'webkitfullscreenchange'
-    ].forEach((fullScreenEvent) => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this)));
+    ]
+    .forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this)));
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
     this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, this._onLoadedMetadata.bind(this));
     this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._onMediaTimeUpdate.bind(this));


### PR DESCRIPTION
### Description of the Changes

Non Linear inline overly isn't in the correct place when full screen in Safari.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
