### PR TITLE
fix(FEC-7158, FEC-7153): set content playeahd tracker events only when ad is idle

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -154,6 +154,7 @@ function onAdStarted(options: Object, adEvent: any): void {
   this._resizeAd();
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {
+    this._setContentPlayheadTrackerEventsEnabled(true);
     this._setVideoEndedCallbackEnabled(true);
     if (this._nextPromise) {
       this._resolveNextPromise();
@@ -161,6 +162,7 @@ function onAdStarted(options: Object, adEvent: any): void {
       this.player.play();
     }
   } else {
+    this._setContentPlayheadTrackerEventsEnabled(false);
     this._startAdInterval();
   }
   this.dispatchEvent(options.transition);
@@ -247,6 +249,7 @@ function onAdBreakStart(options: Object, adEvent: any): void {
 function onAdBreakEnd(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   this._setVideoEndedCallbackEnabled(true);
+  this._setContentPlayheadTrackerEventsEnabled(true);
   if (!this._contentComplete) {
     this._hideAdsContainer();
     this._maybeSetVideoCurrentTime();

--- a/src/ima.js
+++ b/src/ima.js
@@ -319,10 +319,6 @@ export default class Ima extends BasePlugin {
   _addBindings(): void {
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
     this.eventManager.listen(this.player.getVideoElement(), 'resize', this._resizeAd.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, this._onLoadedMetadata.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._onMediaTimeUpdate.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.SEEKING, this._onMediaSeeking.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.SEEKED, this._onMediaSeeked.bind(this));
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, this._syncPlayerVolume.bind(this));
   }
 
@@ -461,6 +457,26 @@ export default class Ima extends BasePlugin {
     if (!this._contentPlayheadTracker.seeking) {
       this._contentPlayheadTracker.previousTime = this._contentPlayheadTracker.currentTime;
       this._contentPlayheadTracker.currentTime = this.player.currentTime;
+    }
+  }
+
+  /**
+   * Sets the content playhead tracker events enabled/disabled.
+   * @param {boolean} enabled - Whether do enabled the events.
+   * @private
+   * @returns {void}
+   */
+  _setContentPlayheadTrackerEventsEnabled(enabled: boolean): void {
+    if (enabled) {
+      this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, this._onLoadedMetadata.bind(this));
+      this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._onMediaTimeUpdate.bind(this));
+      this.eventManager.listen(this.player, this.player.Event.SEEKING, this._onMediaSeeking.bind(this));
+      this.eventManager.listen(this.player, this.player.Event.SEEKED, this._onMediaSeeked.bind(this));
+    } else {
+      this.eventManager.unlisten(this.player, this.player.Event.LOADED_METADATA);
+      this.eventManager.unlisten(this.player, this.player.Event.TIME_UPDATE);
+      this.eventManager.unlisten(this.player, this.player.Event.SEEKING);
+      this.eventManager.unlisten(this.player, this.player.Event.SEEKED);
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

When custom playback was used, the content playhead tracker was updated when ad is playing (since it was playing on the same video tag) and causes wrong tracking.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
