### PR TITLE
fix(FEC-7150, FEC-7120): set content src on custom playback with postroll

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -220,6 +220,9 @@ function onAdCompleted(options: Object, adEvent: any): void {
 function onAllAdsCompleted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   onAdBreakEnd.call(this, options, adEvent);
+  if (this._adsManager.isCustomPlaybackUsed() && this._contentComplete) {
+    this.player.getVideoElement().src = this._contentSrc;
+  }
   this.destroy();
 }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -138,6 +138,12 @@ export default class Ima extends BasePlugin {
    * @private
    */
   _currentAd: any;
+  /**
+   * The content media src.
+   * @member
+   * @private
+   */
+  _contentSrc: string;
 
   /**
    * Whether the ima plugin is valid.
@@ -289,6 +295,9 @@ export default class Ima extends BasePlugin {
       this._nextPromise = Utils.Object.defer();
       this._adDisplayContainer.initialize();
       this.player.ready().then(() => {
+        if (this._adsManager.isCustomPlaybackUsed()) {
+          this._contentSrc = this.player.getVideoElement().src;
+        }
         this._startAdsManager();
       });
       this.player.load();


### PR DESCRIPTION
### Description of the Changes

When custom playback is used (usually on iOS devices) and postroll is done, we need to set the content src on the video tag (seems like the ima sdk doesn't do it for us).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
