### PR TITLE
fix(FEC-7166, FEC-7165, FEC-7159, FEC-7119, FEC-7114): manage races on play

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -19,6 +19,12 @@ export default class ImaMiddleware extends BaseMiddleware {
    * @private
    */
   _context: any;
+  /**
+   * Whether the player has been loaded.
+   * @member
+   * @private
+   */
+  _isPlayerLoaded: boolean;
 
   /**
    * @constructor
@@ -35,6 +41,11 @@ export default class ImaMiddleware extends BaseMiddleware {
    * @returns {void}
    */
   play(next: Function): void {
+    if (!this._isPlayerLoaded) {
+      this._context.player.load();
+      this._isPlayerLoaded = true;
+      this._context.logger.debug("Player loaded");
+    }
     this._context.loadPromise.then(() => {
       let sm = this._context.getStateMachine();
       switch (sm.state) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -362,22 +362,22 @@ export default class Ima extends BasePlugin {
    */
   _init(): void {
     this.loadPromise = Utils.Object.defer();
-    this._isImaSDKLibLoaded()
+    (this._isImaSDKLibLoaded()
       ? Promise.resolve()
-      : Utils.Dom.loadScriptAsync(this.config.debug ? Ima.IMA_SDK_DEBUG_LIB_URL : Ima.IMA_SDK_LIB_URL)
-        .then(() => {
-          this._sdk = window.google.ima;
-          this.logger.debug("IMA SDK version: " + this._sdk.VERSION);
-          this._initImaSettings();
-          this._initAdsContainer();
-          this._initAdsLoader();
-          this._requestAds();
-          this._stateMachine.loaded();
-          this.loadPromise.resolve();
-        })
-        .catch((e) => {
-          this.loadPromise.reject(e);
-        });
+      : Utils.Dom.loadScriptAsync(this.config.debug ? Ima.IMA_SDK_DEBUG_LIB_URL : Ima.IMA_SDK_LIB_URL))
+      .then(() => {
+        this._sdk = window.google.ima;
+        this.logger.debug("IMA SDK version: " + this._sdk.VERSION);
+        this._initImaSettings();
+        this._initAdsContainer();
+        this._initAdsLoader();
+        this._requestAds();
+        this._stateMachine.loaded();
+        this.loadPromise.resolve();
+      })
+      .catch((e) => {
+        this.loadPromise.reject(e);
+      });
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -348,7 +348,10 @@ export default class Ima extends BasePlugin {
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, this._syncPlayerVolume.bind(this));
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, (event) => {
-      this._contentSrc = event.payload.selectedSource[0];
+      let selectedSource = event.payload.selectedSource;
+      if (selectedSource && selectedSource.length > 0) {
+        this._contentSrc = selectedSource[0].url;
+      }
     });
   }
 

--- a/test/src/ima-middleware.spec.js
+++ b/test/src/ima-middleware.spec.js
@@ -6,6 +6,10 @@ describe('Ima Middleware', function () {
   let imaMiddleware;
   let fakeContext = {
     loadPromise: Promise.resolve(),
+    player: {
+      load: function () {
+      }
+    },
     setCurrentState: function (state) {
       this.currentState = state;
     },
@@ -27,6 +31,8 @@ describe('Ima Middleware', function () {
     },
     logger: {
       error: function () {
+      },
+      debug: function () {
       }
     }
   };

--- a/test/src/ima.api.spec.js
+++ b/test/src/ima.api.spec.js
@@ -5,7 +5,7 @@ import Ima from '../../src/ima'
 
 const targetId = 'player-placeholder_ima.api.spec';
 
-describe('Ima API', function () {
+describe.only('Ima API', function () {
 
   let ima;
   let player;

--- a/test/src/ima.api.spec.js
+++ b/test/src/ima.api.spec.js
@@ -5,7 +5,7 @@ import Ima from '../../src/ima'
 
 const targetId = 'player-placeholder_ima.api.spec';
 
-describe.only('Ima API', function () {
+describe('Ima API', function () {
 
   let ima;
   let player;


### PR DESCRIPTION
### Description of the Changes

Requesting ads before user gesture can cause kind of a race condition - if the tap on play was too early and ad manager was still not loaded, a delay timeout of the loadPromise was caused to an ad error event.

Another important change is to load the player ASAP for avoid errors on mobile (mainly on Android/Chrome)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
