### PR TITLE
fix(FEC-7184): remove setDisableCustomPlaybackForIOS10Plus flag

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -399,7 +399,6 @@ export default class Ima extends BasePlugin {
     this._sdk.settings.setPlayerVersion(VERSION);
     this._sdk.settings.setVpaidAllowed(true);
     this._sdk.settings.setVpaidMode(this._sdk.ImaSdkSettings.VpaidMode.ENABLED);
-    this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(true);
   }
 
   /**

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -329,4 +329,25 @@ describe('Ima Plugin', function () {
     });
     player.play();
   });
+
+  it('should play ads and then content with preload="auto"', (done) => {
+    let adPlayed = false;
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator='
+    }, {
+      preload: "auto"
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_STARTED, () => {
+      adPlayed = true;
+    });
+    player.addEventListener(player.Event.PLAYING, () => {
+      if (adPlayed) {
+        done();
+      } else {
+        done(new Error("Content start without ads"));
+      }
+    });
+    player.play();
+  });
 });


### PR DESCRIPTION
### Description of the Changes

This flag disables iOS's native fullscreen and causing problems if playinsline not set to true.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
