### PR TITLE
fix(FEC-7234): pause playback on overlay ad clicked

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -101,7 +101,7 @@ export default class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_CLICKED,
-          from: [State.PLAYING, State.PAUSED]
+          from: [State.PLAYING, State.PAUSED, State.IDLE]
         }
       ],
       methods: {
@@ -176,10 +176,10 @@ function onAdStarted(options: Object, adEvent: any): void {
  */
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  if (this._stateMachine.is(State.PLAYING)) {
-    this.pauseAd();
+  if (this._currentAd.isLinear()) {
+    this._stateMachine.is(State.PLAYING) ? this.pauseAd() : this.resumeAd();
   } else {
-    this.resumeAd();
+    this.player.paused ? this.player.play() : this.player.pause();
   }
   this.dispatchEvent(options.transition);
 }

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -177,9 +177,13 @@ function onAdStarted(options: Object, adEvent: any): void {
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._currentAd.isLinear()) {
-    this._stateMachine.is(State.PLAYING) ? this.pauseAd() : this.resumeAd();
+    if (this._stateMachine.is(State.PLAYING)) {
+      this.pauseAd();
+    }
   } else {
-    this.player.paused ? this.player.play() : this.player.pause();
+    if (!this.player.paused) {
+      this.player.pause();
+    }
   }
   this.dispatchEvent(options.transition);
 }

--- a/test/src/helpers.js
+++ b/test/src/helpers.js
@@ -23,7 +23,9 @@ function loadPlayerWithAds(targetId, imaConfig, playbackConfig) {
   if (playbackConfig) {
     config.playback = playbackConfig;
   }
-  return loadPlayer(targetId, config);
+  let player = loadPlayer(config);
+  document.getElementById(targetId).appendChild(player.getView());
+  return player;
 }
 
 /**
@@ -84,7 +86,7 @@ function registerCompanionSlots() {
   });
 }
 
-export  {
+export {
   loadPlayerWithAds,
   maybeDoneTest,
   loadGPT,


### PR DESCRIPTION
### Description of the Changes

If an overlay ad is playing and user clicked on it, pause video.
If the video is already paused and user clicked on it, play video.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
