### PR TITLE
fix(FEC-7214, FEC-7217, FEC-7214): multiple request ads fix

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -186,18 +186,13 @@ export default class Ima extends BasePlugin {
   }
 
   /**
+   * TODO: Rethink on design and implementation.
    * Plays ad on demand.
    * @param {string} adTagUrl - The ad tag url to play.
    * @returns {void}
    */
   playAdNow(adTagUrl: string): void {
-    super.updateConfig({adTagUrl: adTagUrl});
-    this.loadPromise = Utils.Object.defer();
-    this.destroy();
-    this._addBindings();
-    this._initAdsLoader();
-    this._requestAds();
-    this.loadPromise.then(this._startAdsManager.bind(this));
+    this.logger.warn("playAdNow API is not implemented yet", adTagUrl);
   }
 
   /**
@@ -237,19 +232,6 @@ export default class Ima extends BasePlugin {
     this._nextPromise = Utils.Object.defer();
     this._adsManager.pause();
     return this._nextPromise;
-  }
-
-  /**
-   * Updates the configuration of the plugin.
-   * @param {Object} update - The fully or partially updated configuration.
-   * @override
-   * @returns {void}
-   */
-  updateConfig(update: Object): void {
-    super.updateConfig(update);
-    if (update.adTagUrl && this._stateMachine.is(State.LOADED)) {
-      this._requestAds();
-    }
   }
 
   /**
@@ -397,6 +379,16 @@ export default class Ima extends BasePlugin {
     this._sdk.settings.setPlayerVersion(this.config.playerVersion);
     this._sdk.settings.setVpaidAllowed(true);
     this._sdk.settings.setVpaidMode(this._sdk.ImaSdkSettings.VpaidMode.ENABLED);
+    this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this._isIOS10Plus());
+  }
+
+  _isIOS10Plus(): boolean {
+    try {
+      const os = this.player.env.os;
+      return (os.name === "iOS" && Number.parseFloat(os.version) >= 10);
+    } catch (e) {
+      return false;
+    }
   }
 
   /**

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -119,6 +119,23 @@ describe('Ima Plugin', function () {
     player.play();
   });
 
+  it('should call requestAds once', (done) => {
+    cuePoints = [0];
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator='
+    });
+    ima = player._pluginManager.get('ima');
+    const spy = sinon.spy(ima, "_requestAds");
+    player.addEventListener(player.Event.AD_LOADED, (e) => {
+      adPodIndex = e.payload.extraAdData.adPodInfo.podIndex;
+      spy.should.calledOnce;
+    });
+    player.addEventListener(player.Event.AD_STARTED, () => {
+      maybeDoneTest(cuePoints, adPodIndex, done);
+    });
+    player.play();
+  });
+
   it('should play vmap-preroll-bumper', (done) => {
     cuePoints = [0, 0];
     player = loadPlayerWithAds(targetId, {


### PR DESCRIPTION
### Description of the Changes

Because of overriding updateConfig we're calling twice to requestAds what causing empty vast response and ad error.
We need to re-think on design and implementation of 2 features:
* Create IMA plugin without ad tag ad configure it later.
* Play ad on demand

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
