### PR TITLE
fix(FEC-7199): handling setDisableCustomPlaybackForIOS10Plus

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -33,6 +33,7 @@ export default class Ima extends BasePlugin {
   static defaultConfig: Object = {
     debug: false,
     companions: {},
+    setDisableCustomPlaybackForIOS10Plus: null,
     adsRenderingSettings: {
       restoreCustomPlaybackStateOnAdBreakComplete: true,
       enablePreloading: false,
@@ -423,6 +424,11 @@ export default class Ima extends BasePlugin {
     this._sdk.settings.setPlayerVersion(this.config.playerVersion);
     this._sdk.settings.setVpaidAllowed(true);
     this._sdk.settings.setVpaidMode(this._sdk.ImaSdkSettings.VpaidMode.ENABLED);
+    if (this.config.setDisableCustomPlaybackForIOS10Plus === 'boolean') {
+      this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this.config.setDisableCustomPlaybackForIOS10Plus);
+    } else {
+      this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this.player.config.playsinline);
+    }
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -427,7 +427,7 @@ export default class Ima extends BasePlugin {
     if (this.config.setDisableCustomPlaybackForIOS10Plus === 'boolean') {
       this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this.config.setDisableCustomPlaybackForIOS10Plus);
     } else {
-      this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this.player.config.playsinline);
+      this._sdk.settings.setDisableCustomPlaybackForIOS10Plus(this.player.config.playback.playsinline);
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Sets ima setting  setDisableCustomPlaybackForIOS10Plus according to the player's playsinline config.
If setDisableCustomPlaybackForIOS10Plus is configured by the user, it is the strongest config.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
