### PR TITLE
fix(FEC-7372, FEC-7369, FEC-7376, FEC-7386): fallback to mute issue

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -110,7 +110,7 @@ export default class ImaStateMachine {
       methods: {
         onAdloaded: onAdLoaded.bind(context),
         onAdstarted: onAdStarted.bind(context),
-        onAdpaused: onAdPaused.bind(context),
+        onAdpaused: onAdEvent.bind(context),
         onAdresumed: onAdEvent.bind(context),
         onAdclicked: onAdClicked.bind(context),
         onAdskipped: onAdSkipped.bind(context),
@@ -193,17 +193,6 @@ function onAdClicked(options: Object, adEvent: any): void {
       this.player.pause();
     }
   }
-  this.dispatchEvent(options.transition);
-}
-
-/**
- * PAUSED event handler.
- * @param {Object} options - fsm event data.
- * @param {any} adEvent - ima event data.
- * @returns {void}
- */
-function onAdPaused(options: Object, adEvent: any): void {
-  this.logger.debug(adEvent.type.toUpperCase());
   this.dispatchEvent(options.transition);
 }
 


### PR DESCRIPTION
### Description of the Changes

Listen also for MUTE_CHANGE event from the player to change the adsManager volume, so the flow after user action will be synchronously.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
