### PR TITLE
fix(FEC-7365): when click again on paused ad the ad resumed but click-through site is open again

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,0 +1,12 @@
+.playkit-ads-cover {
+  position: fixed;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.playkit-ads-container {
+  position: absolute;
+  top: 0;
+}

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -111,7 +111,7 @@ export default class ImaStateMachine {
         onAdloaded: onAdLoaded.bind(context),
         onAdstarted: onAdStarted.bind(context),
         onAdpaused: onAdEvent.bind(context),
-        onAdresumed: onAdEvent.bind(context),
+        onAdresumed: onAdResumed.bind(context),
         onAdclicked: onAdClicked.bind(context),
         onAdskipped: onAdSkipped.bind(context),
         onAdcompleted: onAdCompleted.bind(context),
@@ -185,14 +185,25 @@ function onAdClicked(options: Object, adEvent: any): void {
   if (this._currentAd.isLinear()) {
     if (this._stateMachine.is(State.PLAYING)) {
       this.pauseAd();
-    } else if (this._stateMachine.is(State.PAUSED)) {
-      this.resumeAd();
+      this._setToggleAdsCover(true);
     }
   } else {
     if (!this.player.paused) {
       this.player.pause();
     }
   }
+  this.dispatchEvent(options.transition);
+}
+
+/**
+ * RESUMED event handler.
+ * @param {Object} options - fsm event data.
+ * @param {any} adEvent - ima event data.
+ * @returns {void}
+ */
+function onAdResumed(options: Object, adEvent: any): void {
+  this.logger.debug(adEvent.type.toUpperCase());
+  this._setToggleAdsCover(false);
   this.dispatchEvent(options.transition);
 }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -791,8 +791,10 @@ export default class Ima extends BasePlugin {
    */
   _setToggleAdsCover(enable: boolean): void {
     if (enable) {
-      this._adsContainerDiv.appendChild(this._adsCoverDiv);
-      this._isAdsCoverActive = true;
+      if (!this._adsManager.isCustomPlaybackUsed()) {
+        this._adsContainerDiv.appendChild(this._adsCoverDiv);
+        this._isAdsCoverActive = true;
+      }
     } else {
       if (this._isAdsCoverActive) {
         this._adsContainerDiv.removeChild(this._adsCoverDiv);

--- a/src/ima.js
+++ b/src/ima.js
@@ -5,6 +5,7 @@ import State from './state'
 import {registerPlugin, BasePlugin} from 'playkit-js'
 import {BaseMiddleware} from 'playkit-js'
 import {Utils} from 'playkit-js'
+import './assets/style.css'
 
 /**
  * The plugin name.
@@ -13,11 +14,17 @@ import {Utils} from 'playkit-js'
  */
 const pluginName: string = "ima";
 /**
- * The ads container id.
+ * The ads container class.
  * @type {string}
  * @const
  */
-const ADS_CONTAINER_ID: string = "playkit-ads-container";
+const ADS_CONTAINER_CLASS: string = "playkit-ads-container";
+/**
+ * The ads cover class.
+ * @type {string}
+ * @const
+ */
+const ADS_COVER_CLASS: string = "playkit-ads-cover";
 
 /**
  * The ima plugin.
@@ -84,6 +91,12 @@ export default class Ima extends BasePlugin {
    * @private
    */
   _adsContainerDiv: HTMLElement;
+  /**
+   * The ads cover dom element.
+   * @member
+   * @private
+   */
+  _adsCoverDiv: HTMLElement;
   /**
    * The ima ads container object.
    */
@@ -161,6 +174,12 @@ export default class Ima extends BasePlugin {
    * @private
    */
   _togglePlayPauseOnAdsContainerCallback: ?Function;
+  /**
+   * Whether the ads cover overlay is active.
+   * @member
+   * @private
+   */
+  _isAdsCoverActive: boolean;
 
   /**
    * Whether the ima plugin is valid.
@@ -438,17 +457,18 @@ export default class Ima extends BasePlugin {
    */
   _initAdsContainer(): void {
     this.logger.debug("Init ads container");
-    let adsContainerDiv = Utils.Dom.getElementById(ADS_CONTAINER_ID);
-    if (!adsContainerDiv) {
-      let playerView = this.player.getView();
-      this._adsContainerDiv = Utils.Dom.createElement('div');
-      this._adsContainerDiv.id = ADS_CONTAINER_ID + playerView.id;
-      this._adsContainerDiv.style.position = "absolute";
-      this._adsContainerDiv.style.top = "0px";
-      Utils.Dom.appendChild(playerView, this._adsContainerDiv);
-    } else {
-      this._adsContainerDiv = adsContainerDiv;
-    }
+    const playerView = this.player.getView();
+    // Create ads container
+    this._adsContainerDiv = Utils.Dom.createElement('div');
+    this._adsContainerDiv.id = ADS_CONTAINER_CLASS + playerView.id;
+    this._adsContainerDiv.className = ADS_CONTAINER_CLASS;
+    // Create ads cover
+    this._adsCoverDiv = Utils.Dom.createElement('div');
+    this._adsCoverDiv.id = ADS_COVER_CLASS + playerView.id;
+    this._adsCoverDiv.className = ADS_COVER_CLASS;
+    this._adsCoverDiv.onclick = () => this.resumeAd();
+    // Append the ads container to the dom
+    Utils.Dom.appendChild(playerView, this._adsContainerDiv);
     this._adDisplayContainer = new this._sdk.AdDisplayContainer(this._adsContainerDiv, this.player.getVideoElement());
   }
 
@@ -760,6 +780,24 @@ export default class Ima extends BasePlugin {
     if (this._nextPromise) {
       this._nextPromise.resolve();
       this._nextPromise = null;
+    }
+  }
+
+  /**
+   * Toggle the ads cover div.
+   * @param {boolean} enable - Whether to add or remove the ads cover.
+   * @private
+   * @returns {void}
+   */
+  _setToggleAdsCover(enable: boolean): void {
+    if (enable) {
+      this._adsContainerDiv.appendChild(this._adsCoverDiv);
+      this._isAdsCoverActive = true;
+    } else {
+      if (this._isAdsCoverActive) {
+        this._adsContainerDiv.removeChild(this._adsCoverDiv);
+        this._isAdsCoverActive = false;
+      }
     }
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,10 @@ module.exports = {
   devtool: 'source-map',
   plugins: PROD ? [new webpack.optimize.UglifyJsPlugin({sourceMap: true})] : [],
   module: {
+    loaders: [{
+      test: /\.css$/,
+      loader: "style-loader!css-loader"
+    }],
     rules: [{
       test: /\.js$/,
       use: [{


### PR DESCRIPTION
### Description of the Changes

Add ad cover overlay on ad paused, remove it on ad resumed.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
