### PR TITLE
fix(FEC-7516): fix IMA get stuck when ad response is bad

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -65,7 +65,7 @@ export default class ImaMiddleware extends BaseMiddleware {
         case State.PAUSED: {
           const resumeAd = this._context.resumeAd();
           if (resumeAd) {
-            resumeAd.then(() => {
+            return resumeAd.then(() => {
               this.callNext(next);
             });
           } else {

--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -54,7 +54,7 @@ export default class ImaMiddleware extends BaseMiddleware {
         case State.LOADED: {
           const initialUserAction = this._context.initialUserAction();
           if (initialUserAction) {
-            initialUserAction.then(() => {
+            return initialUserAction.then(() => {
               this.callNext(next);
             });
           } else {

--- a/test/src/ima-middleware.spec.js
+++ b/test/src/ima-middleware.spec.js
@@ -63,6 +63,18 @@ describe('Ima Middleware', function () {
       });
     });
 
+    it('should destory adsManager and resume playback in case of error', function (done) {
+      let spy = sandbox.spy(fakeContext, 'destroy');
+      fakeContext.setCurrentState(State.LOADED);
+      fakeContext.initialUserAction = Promise.reject();
+      imaMiddleware = new ImaMiddleware(fakeContext);
+      imaMiddleware.play(function () {
+        spy.should.have.been.calledOnce;
+        fakeContext.initialUserAction = Promise.resolve();
+        done();
+      });
+    });
+
     it('should resumeAd', function (done) {
       let spy = sandbox.spy(fakeContext, 'resumeAd');
       fakeContext.setCurrentState(State.PAUSED);


### PR DESCRIPTION
### Description of the Changes

when ad response is malformed we get a rejection of promise, but because int's a nested promise and we didn't `return` it then the external `catch` didn't get triggered and the code flow got stuck.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
