### PR TITLE
fix(FEC-7516): player gets stuck when ima plugin is empty

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -332,7 +332,7 @@ export default class Ima extends BasePlugin {
       this._adDisplayContainer.initialize();
       this._hasUserAction = true;
       if (!this.config.adTagUrl) {
-        this._nextPromise.resolve();
+        this._resolveNextPromise();
       }
       if (this._isAdsManagerLoaded) {
         this.logger.debug("User action occurred after ads manager loaded");

--- a/src/ima.js
+++ b/src/ima.js
@@ -331,6 +331,9 @@ export default class Ima extends BasePlugin {
       this._nextPromise = Utils.Object.defer();
       this._adDisplayContainer.initialize();
       this._hasUserAction = true;
+      if (!this.config.adTagUrl) {
+        this._nextPromise.resolve();
+      }
       if (this._isAdsManagerLoaded) {
         this.logger.debug("User action occurred after ads manager loaded");
         this._startAdsManager();

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -368,4 +368,13 @@ describe('Ima Plugin', function () {
     });
     player.play();
   });
+
+  it('should play the content immediately for empty config', (done) => {
+    player = loadPlayerWithAds(targetId, {});
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.PLAYING, () => {
+      done();
+    });
+    player.play();
+  });
 });


### PR DESCRIPTION
### Description of the Changes

resolve the `_nextPromise` immediately if no adTagUrl given, to not block the play middleware chain

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated

  