### PR TITLE
fix(FEC-7502, FEC-7455): Video stuck after the ad ,In case user was selecting learn more during ad and select Play (big icon)

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -51,6 +51,8 @@ export default class ImaMiddleware extends BaseMiddleware {
     this._context.loadPromise.then(() => {
       let sm = this._context.getStateMachine();
       switch (sm.state) {
+        case State.PLAYING:
+          break;
         case State.LOADED: {
           const initialUserAction = this._context.initialUserAction();
           if (initialUserAction) {
@@ -93,6 +95,8 @@ export default class ImaMiddleware extends BaseMiddleware {
   pause(next: Function): void {
     let sm = this._context.getStateMachine();
     switch (sm.state) {
+      case State.PAUSED:
+        break;
       case State.PLAYING: {
         this._context.pauseAd();
         break;

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -189,7 +189,7 @@ function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._currentAd.isLinear()) {
     if (this._stateMachine.is(State.PLAYING)) {
-      this.pauseAd();
+      this._adsManager.pause();
       this._setToggleAdsCover(true);
     }
   } else {

--- a/src/ima.js
+++ b/src/ima.js
@@ -469,7 +469,7 @@ export default class Ima extends BasePlugin {
     this._adsCoverDiv = Utils.Dom.createElement('div');
     this._adsCoverDiv.id = ADS_COVER_CLASS + playerView.id;
     this._adsCoverDiv.className = ADS_COVER_CLASS;
-    this._adsCoverDiv.onclick = () => this.resumeAd();
+    this._adsCoverDiv.onclick = () => this._onAdsCoverClicked();
     // Append the ads container to the dom
     Utils.Dom.appendChild(playerView, this._adsContainerDiv);
     this._adDisplayContainer = new this._sdk.AdDisplayContainer(this._adsContainerDiv, this.player.getVideoElement());
@@ -817,6 +817,18 @@ export default class Ima extends BasePlugin {
    */
   _onAdsContainerClicked(): void {
     this.player.paused ? this.player.play() : this.player.pause();
+  }
+
+
+  /**
+   * On ads cover click handler.
+   * @private
+   * @returns {void}
+   */
+  _onAdsCoverClicked(): void {
+    if (this._adsManager) {
+      this._adsManager.resume();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Inside the plugin use only IMA's adsManager API and not plugin API which overrides the next promise.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
