### PR TITLE
fix(FEC-7898): After pausing ad, each time clicking on the Ad area Ad info displayed (and video is not Playing)

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -190,8 +190,8 @@ function onAdClicked(options: Object, adEvent: any): void {
   if (this._currentAd.isLinear()) {
     if (this._stateMachine.is(State.PLAYING)) {
       this.pauseAd();
-      this._setToggleAdsCover(true);
     }
+    this._setToggleAdsCover(true);
   } else {
     if (!this.player.paused) {
       this.player.pause();


### PR DESCRIPTION
### Description of the Changes

Move the `_setToggleAdsCover ` also if ad clicked when its not playing.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
