### PR TITLE
fix(FEC-7915): When selecting learn more (long press) on pre-roll the ad page is opening and video continues to play

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -827,7 +827,16 @@ export default class Ima extends BasePlugin {
    */
   _onAdsCoverClicked(): void {
     if (this._adsManager) {
-      this._adsManager.resume();
+      switch (this._stateMachine.state) {
+        case State.PAUSED:
+          this._adsManager.resume();
+          break;
+        case State.PLAYING:
+          this._adsManager.pause();
+          break;
+        default:
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

For some reason on mobiles the click on 'Learn More' is catching on the ad cover, so need to check what to do depends on the plugin state.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
