### PR TITLE
fix(FEC-7403): [DFP_Preroll][Android] - When tapping on learn more on a pre roll, then closing the new opened tab, the video is not playing

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -104,7 +104,7 @@ export default class ImaMiddleware extends BaseMiddleware {
    */
   _maybePreloadPlayer(): void {
     const ctx = this._context;
-    if (ctx.isFallbackToMutedAutoPlay && !ctx.isPlayerLoaded) {
+    if (!ctx.isFallbackToMutedAutoPlay && !ctx.isPlayerLoaded) {
       ctx.player.load();
       ctx.isPlayerLoaded = true;
       ctx.logger.debug("Player loaded via middleware");

--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -15,12 +15,6 @@ export default class ImaMiddleware extends BaseMiddleware {
    */
   id: string = "ImaMiddleware";
   /**
-   * Whether the player has been loaded.
-   * @member
-   * @private
-   */
-  _isPlayerLoaded: boolean;
-  /**
    * The plugin context.
    * @member
    * @private
@@ -34,7 +28,6 @@ export default class ImaMiddleware extends BaseMiddleware {
   constructor(context: Ima) {
     super();
     this._context = context;
-    context.player.addEventListener(context.player.Event.CHANGE_SOURCE_STARTED, () => this._isPlayerLoaded = false);
   }
 
   /**
@@ -43,11 +36,7 @@ export default class ImaMiddleware extends BaseMiddleware {
    * @returns {void}
    */
   play(next: Function): void {
-    if (!this._isPlayerLoaded) {
-      this._context.player.load();
-      this._isPlayerLoaded = true;
-      this._context.logger.debug("Player loaded");
-    }
+    this._maybePreloadPlayer();
     this._context.loadPromise.then(() => {
       let sm = this._context.getStateMachine();
       switch (sm.state) {
@@ -105,6 +94,20 @@ export default class ImaMiddleware extends BaseMiddleware {
         this.callNext(next);
         break;
       }
+    }
+  }
+
+  /**
+   * Maybe preload the content player.
+   * @private
+   * @returns {void}
+   */
+  _maybePreloadPlayer(): void {
+    const ctx = this._context;
+    if (ctx.isFallbackToMutedAutoPlay && !ctx.isPlayerLoaded) {
+      ctx.player.load();
+      ctx.isPlayerLoaded = true;
+      ctx.logger.debug("Player loaded via middleware");
     }
   }
 }

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -188,9 +188,8 @@ function onAdStarted(options: Object, adEvent: any): void {
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._currentAd.isLinear()) {
-    if (this._stateMachine.is(State.PLAYING)) {
-      this._adsManager.pause();
-    }
+    this._maybePreloadPlayerOnAdsContainerClick();
+    this._adsManager.pause();
     this._setToggleAdsCover(true);
   } else {
     if (!this.player.paused) {
@@ -208,6 +207,7 @@ function onAdClicked(options: Object, adEvent: any): void {
  */
 function onAdResumed(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
+  this._maybeForceAdPause();
   this._setToggleAdsCover(false);
   this.dispatchEvent(options.transition);
 }
@@ -267,6 +267,7 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
   this._setVideoEndedCallbackEnabled(true);
   this._setContentPlayheadTrackerEventsEnabled(true);
   if (!this._contentComplete) {
+    this._maybePreloadPlayerWhenAdBreakEnd();
     this._hideAdsContainer();
     this._maybeSetVideoCurrentTime();
     if (this._nextPromise) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -297,9 +297,7 @@ export default class Ima extends BasePlugin {
    */
   pauseAd(): ?DeferredPromise {
     this.logger.debug("Pause ad");
-    this._nextPromise = Utils.Object.defer();
     this._adsManager.pause();
-    return this._nextPromise;
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -8,6 +8,12 @@ import {Utils} from 'playkit-js'
 import './assets/style.css'
 
 /**
+ * The full screen events list.
+ * @type {Array<string>}
+ * @const
+ */
+const FULL_SCREEN_EVENTS = ['fullscreenchange', 'mozfullscreenchange', 'webkitfullscreenchange'];
+/**
  * The ads container class.
  * @type {string}
  * @const
@@ -177,6 +183,22 @@ export default class Ima extends BasePlugin {
    * @private
    */
   _isAdsCoverActive: boolean;
+
+  _isFallbackToMutedAutoPlay: boolean;
+
+  _isPlayerLoaded: boolean;
+
+  set isPlayerLoaded(value: boolean): void {
+    this._isPlayerLoaded = value;
+  }
+
+  get isPlayerLoaded(): boolean {
+    return this._isPlayerLoaded;
+  }
+
+  get isFallbackToMutedAutoPlay(): boolean {
+    return this._isFallbackToMutedAutoPlay;
+  }
 
   /**
    * Whether the ima plugin is valid.
@@ -365,14 +387,12 @@ export default class Ima extends BasePlugin {
    * @returns {void}
    */
   _addBindings(): void {
-    [
-      'fullscreenchange',
-      'mozfullscreenchange',
-      'webkitfullscreenchange'
-    ].forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this)));
+    FULL_SCREEN_EVENTS.forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, this._resizeAd.bind(this)));
     this.eventManager.listen(window, 'resize', this._resizeAd.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, this._syncPlayerVolume.bind(this));
-    this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, this._syncPlayerVolume.bind(this));
+    this.eventManager.listen(this.player, this.player.Event.FALLBACK_TO_MUTED_AUTOPLAY, () => this._isFallbackToMutedAutoPlay = true);
+    this.eventManager.listen(this.player, this.player.Event.CHANGE_SOURCE_STARTED, () => this._isPlayerLoaded = false);
+    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume());
+    this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, (event) => {
       let selectedSource = event.payload.selectedSource;
       if (selectedSource && selectedSource.length > 0) {
@@ -819,7 +839,6 @@ export default class Ima extends BasePlugin {
     this.player.paused ? this.player.play() : this.player.pause();
   }
 
-
   /**
    * On ads cover click handler.
    * @private
@@ -868,6 +887,58 @@ export default class Ima extends BasePlugin {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Attach the ads container div a listener which pre loads the content player.
+   * Only relevant on auto play mode.
+   * @private
+   * @returns {void}
+   */
+  _maybePreloadPlayerOnAdsContainerClick(): void {
+    if (!this._isPlayerLoaded && this._isFallbackToMutedAutoPlay) {
+      this._waitingForAdsContainerClick = true;
+      const onAdsContainerClicked = () => {
+        this._adsContainerClicked = true;
+        this.player.load();
+        this._isPlayerLoaded = true;
+        this.logger.debug("Player load as a result of ads container clicked");
+      };
+      setTimeout(() => {
+        this.eventManager.listenOnce(this._adsContainerDiv, "click", onAdsContainerClicked);
+      }, 0);
+    }
+  }
+
+  /**
+   * If RESUME event is not triggered as a result of user gesture
+   * we need to pause the ad to enforce user gesture.
+   * Only relevant on auto play mode.
+   * @private
+   * @returns {void}
+   */
+  _maybeForceAdPause(): void {
+    if (!this._isPlayerLoaded && this._isFallbackToMutedAutoPlay) {
+      if (this._waitingForAdsContainerClick && !this._adsContainerClicked) {
+        this._adsManager.pause();
+        this._adsContainerClicked = true;
+        this._waitingForAdsContainerClick = false;
+      }
+    }
+  }
+
+  /**
+   * Pre loads the content player if ad break ended and we didn't got user gesture.
+   * Only relevant on auto play mode.
+   * @private
+   * @returns {void}
+   */
+  _maybePreloadPlayerWhenAdBreakEnd(): void {
+    if (!this._isPlayerLoaded && this._isFallbackToMutedAutoPlay) {
+      this.player.load();
+      this._isPlayerLoaded = true;
+      this.logger.debug("Player load on ad break end");
     }
   }
 }

--- a/src/ima.js
+++ b/src/ima.js
@@ -183,19 +183,48 @@ export default class Ima extends BasePlugin {
    * @private
    */
   _isAdsCoverActive: boolean;
-
+  /**
+   * Indicates whether we are on muted auto play mode.
+   * @member
+   * @private
+   */
   _isFallbackToMutedAutoPlay: boolean;
-
+  /**
+   * Indicates whether the content player is pre loaded.
+   * @member
+   * @private
+   */
   _isPlayerLoaded: boolean;
+  /**
+   * Indicates whether we need programmatically pause ad to enforce user gesture on resume event.
+   * @member
+   * @private
+   */
+  _waitingForAdsContainerClick: boolean;
+  /**
+   * Indicates whether an ads container click has been triggered the resume event.
+   * @member
+   * @private
+   */
+  _adsContainerClicked: boolean;
 
+  /**
+   * @param {boolean} value - Preload value.
+   */
   set isPlayerLoaded(value: boolean): void {
     this._isPlayerLoaded = value;
   }
 
+  /**
+   * @returns {boolean} - Whether the content player is pre loaded.
+   */
   get isPlayerLoaded(): boolean {
     return this._isPlayerLoaded;
   }
 
+  /**
+   * @returns {boolean} - Whether we are on muted auto play mode.
+   */
   get isFallbackToMutedAutoPlay(): boolean {
     return this._isFallbackToMutedAutoPlay;
   }


### PR DESCRIPTION
### Description of the Changes

On muted auto play mode preload the content player on user gesture or on ad break end (this first which will happen).


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
