### PR TITLE
fix(FEC-7403): [DFP_Preroll][Android] - When tapping on learn more on a pre roll, then closing the new opened tab, the video is not playing

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -188,6 +188,7 @@ function onAdStarted(options: Object, adEvent: any): void {
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._currentAd.isLinear()) {
+    this._maybeIgnoreClickOnAd();
     if (this._stateMachine.is(State.PLAYING)) {
       this._adsManager.pause();
     }

--- a/src/ima.js
+++ b/src/ima.js
@@ -870,4 +870,18 @@ export default class Ima extends BasePlugin {
       }
     }
   }
+
+  /**
+   * On Chrome-Android we're ignoring LearnMore click to enable
+   * video element manipulation only on user gesture.
+   * @private
+   * @returns {void}
+   */
+  _maybeIgnoreClickOnAd(): void {
+    const isAndroid = () => this.player.env.os.name === 'Android';
+    const isChrome = () => this.player.env.browser.name === 'Chrome';
+    if (isAndroid() && isChrome()) {
+      this.eventManager.listenOnce(this.player.getView(), 'click', e => e.stopPropagation());
+    }
+  }
 }


### PR DESCRIPTION
### Description of the Changes

Ignoring LearnMore click to enable video element manipulation only on user gesture.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
