### PR TITLE
fix: wait for source before preloading the entry 

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -44,9 +44,16 @@ export default class ImaMiddleware extends BaseMiddleware {
    */
   play(next: Function): void {
     if (!this._isPlayerLoaded) {
-      this._context.player.load();
-      this._isPlayerLoaded = true;
-      this._context.logger.debug("Player loaded");
+      const loadPlayer = () => {
+        this._context.logger.debug("Player loaded");
+        this._context.player.load();
+        this._isPlayerLoaded = true;
+      };
+      if (this._context.player.engineType) { // player has source to play
+        loadPlayer();
+      } else {
+        this._context.player.addEventListener(this._context.player.Event.SOURCE_SELECTED, () => loadPlayer());
+      }
     }
     this._context.loadPromise.then(() => {
       let sm = this._context.getStateMachine();

--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -44,16 +44,7 @@ export default class ImaMiddleware extends BaseMiddleware {
    */
   play(next: Function): void {
     if (!this._isPlayerLoaded) {
-      const loadPlayer = () => {
-        this._context.logger.debug("Player loaded");
-        this._context.player.load();
-        this._isPlayerLoaded = true;
-      };
-      if (this._context.player.engineType) { // player has source to play
-        loadPlayer();
-      } else {
-        this._context.player.addEventListener(this._context.player.Event.SOURCE_SELECTED, () => loadPlayer());
-      }
+      this._loadPlayer();
     }
     this._context.loadPromise.then(() => {
       let sm = this._context.getStateMachine();
@@ -112,6 +103,24 @@ export default class ImaMiddleware extends BaseMiddleware {
         this.callNext(next);
         break;
       }
+    }
+  }
+
+  /**
+   * Load the player.
+   * @returns {void}
+   * @private
+   */
+  _loadPlayer(): void {
+    const loadPlayer = () => {
+      this._context.logger.debug("Load player by ima middleware");
+      this._context.player.load();
+      this._isPlayerLoaded = true;
+    };
+    if (this._context.player.engineType) { // player has source to play
+      loadPlayer();
+    } else {
+      this._context.player.addEventListener(this._context.player.Event.SOURCE_SELECTED, () => loadPlayer());
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes
Following https://github.com/kaltura/playkit-js/pull/197 playing an ad can be before `sourceselected` event, so we have to consider this use case when ima preloads the source 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
