### PR TITLE
fix(FEC-8065): protect against accessing IMA SDK when it is not loaded

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -288,6 +288,9 @@ export default class Ima extends BasePlugin {
     this.eventManager.removeAll();
     this._stopAdInterval();
     this._hideAdsContainer();
+    if (!this._isImaSDKLibLoaded()){
+      return;
+    }
     if (this._adsManager) {
       this._adsManager.destroy();
     }


### PR DESCRIPTION
### Description of the Changes

When ad blocker is active then IMA SDK doesn't load.
We protect against such case for the current playback and avoid accessing IMA SDK, but on change media we don't check this condition again and call the IMA SDK, which doesn't exist, and this crash the player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
