### PR TITLE
feat(FEC-7814): add setAdWillAutoPlay and setAdWillPlayMuted support

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -525,22 +525,22 @@ export default class Ima extends BasePlugin {
       //Pass signal to IMA SDK if ad will autoplay with sound
       //First let application config this, otherwise if player is configured
       // to autoplay then try to autodetect if unmuted autoplay is supported
-      if (typeof(adWillAutoPlay) === "boolean"){
+      if (typeof(adWillAutoPlay) === "boolean") {
         adsRequest.setAdWillAutoPlay(adWillAutoPlay);
         this._adsLoader.requestAds(adsRequest);
-      } else if (playerWillAutoPlay){
+      } else if (playerWillAutoPlay) {
         getCapabilities(EngineType.HTML5).then(capabilities => {
           if (capabilities.autoplay) {
             adsRequest.setAdWillAutoPlay(true);
           }
-          else if (allowMutedAutoPlay && capabilities.mutedAutoPlay){
+          else if (allowMutedAutoPlay && capabilities.mutedAutoPlay) {
             adsRequest.setAdWillAutoPlay(true);
             adsRequest.setAdWillPlayMuted(true);
           } else {
             adsRequest.setAdWillAutoPlay(false);
           }
           this._adsLoader.requestAds(adsRequest);
-        })
+        });
       } else {
         adsRequest.setAdWillAutoPlay(false);
         this._adsLoader.requestAds(adsRequest);

--- a/src/ima.js
+++ b/src/ima.js
@@ -538,7 +538,6 @@ export default class Ima extends BasePlugin {
             adsRequest.setAdWillPlayMuted(true);
           } else {
             adsRequest.setAdWillAutoPlay(false);
-            adsRequest.setAdWillPlayMuted(false);
           }
           this._adsLoader.requestAds(adsRequest);
         })


### PR DESCRIPTION
### Description of the Changes

Following the new autoplay changes in Chrome and other browsers IMA are making autoplay and muted playback as key attributes in their attribution and ad buying process.
As part of this they are requesting that the following APIs will be set accordingly so this data, if ad will be played autoplay or/and muted, will be passed to the ad server.
Setting of the data is via API:
[setAdWillAutoPlay](https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRequest.setAdWillAutoPlay)
[setAdWillPlayMuted](https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRequest.setAdWillPlayMuted)
See:
https://github.com/googleads/googleads-ima-html5/blob/master/attempt_to_autoplay/ads.js

**Still need to add docs update**

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
