### PR TITLE
fix(FEC-8107):  ad video fails to play and only ad audio plays in full screen mode

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -254,6 +254,7 @@ function onAdBreakStart(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   this.player.pause();
   this._setVideoEndedCallbackEnabled(false);
+  this._maybeForceExitFullScreen();
   this._maybeSaveVideoCurrentTime();
   this.dispatchEvent(options.transition);
 }

--- a/src/ima.js
+++ b/src/ima.js
@@ -2,7 +2,7 @@
 import ImaMiddleware from './ima-middleware'
 import ImaStateMachine from './ima-state-machine'
 import State from './state'
-import {BaseMiddleware, BasePlugin, Utils, getCapabilities, EngineType} from 'playkit-js'
+import {BaseMiddleware, BasePlugin, EngineType, getCapabilities, Utils} from 'playkit-js'
 import './assets/style.css'
 
 /**
@@ -42,7 +42,6 @@ export default class Ima extends BasePlugin {
   static defaultConfig: Object = {
     debug: false,
     disableMediaPreload: false,
-    setDisableCustomPlaybackForIOS10Plus: null,
     adsRenderingSettings: {
       restoreCustomPlaybackStateOnAdBreakComplete: true,
       enablePreloading: false,
@@ -922,6 +921,20 @@ export default class Ima extends BasePlugin {
     const isChrome = () => this.player.env.browser.name === 'Chrome';
     if (isAndroid() && isChrome()) {
       this.eventManager.listenOnce(this.player.getView(), 'click', e => e.stopPropagation());
+    }
+  }
+
+  /**
+   * When playing with different video tags on iOS ads are not
+   * supported in native full screen, so need to exist full screen before ads started.
+   * @private
+   * @returns {void}
+   */
+  _maybeForceExitFullScreen(): void {
+    const isIOS = () => this.player.env.os.name === 'iOS';
+    if (isIOS() && !this._adsManager.isCustomPlaybackUsed()
+      && this.player.isFullscreen()) {
+      this.player.exitFullscreen();
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

When playing with different video tags on iOS ads are not
supported in native full screen, so need to exist full screen before ads started.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
