### PR TITLE
fix(FEC-8111, FEC-8022): set ads container dimensions according to the ad width/height

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -8,5 +8,4 @@
 
 .playkit-ads-container {
   position: absolute;
-  top: 0;
 }

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -166,8 +166,6 @@ function onAdStarted(options: Object, adEvent: any): void {
   if (!this._currentAd.isLinear()) {
     this._setContentPlayheadTrackerEventsEnabled(true);
     this._setVideoEndedCallbackEnabled(true);
-    this._togglePlayPauseOnAdsContainerCallback = this._onAdsContainerClicked.bind(this);
-    this._setTogglePlayPauseOnAdsContainerEnabled(true);
     if (this._nextPromise) {
       this._resolveNextPromise();
     } else {

--- a/src/ima.js
+++ b/src/ima.js
@@ -17,7 +17,7 @@ const FULL_SCREEN_EVENTS: Array<string> = [
 ];
 
 /**
- * The overlay ad height offset.
+ * The overlay ad margin.
  * @type {number}
  * @const
  */

--- a/src/ima.js
+++ b/src/ima.js
@@ -21,7 +21,7 @@ const FULL_SCREEN_EVENTS: Array<string> = [
  * @type {number}
  * @const
  */
-const OVERLAY_AD_HEIGHT_OFFSET: number = 8;
+const OVERLAY_AD_MARGIN: number = 8;
 /**
  * The ads container class.
  * @type {string}
@@ -567,7 +567,7 @@ export default class Ima extends BasePlugin {
         this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
       } else {
         this._alignAdsContainerSizeForOverlayAd();
-        this._adsManager.resize(this._currentAd.getWidth() + OVERLAY_AD_HEIGHT_OFFSET, this._currentAd.getHeight() + OVERLAY_AD_HEIGHT_OFFSET, viewMode);
+        this._adsManager.resize(this._currentAd.getWidth() + OVERLAY_AD_MARGIN, this._currentAd.getHeight() + OVERLAY_AD_MARGIN, viewMode);
       }
     }
   }
@@ -578,7 +578,7 @@ export default class Ima extends BasePlugin {
    * @returns {void}
    */
   _alignAdsContainerSizeForOverlayAd(): void {
-    this._adsContainerDiv.style.bottom = this._currentAd.getHeight() + OVERLAY_AD_HEIGHT_OFFSET + 'px';
+    this._adsContainerDiv.style.bottom = this._currentAd.getHeight() + OVERLAY_AD_MARGIN + 'px';
     this._adsContainerDiv.style.left = (this.player.dimensions.width - this._currentAd.getWidth()) / 2 + 'px';
   }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -394,7 +394,6 @@ export default class Ima extends BasePlugin {
    * @returns {void}
    */
   _initMembers(): void {
-    this._setTogglePlayPauseOnAdsContainerEnabled(false);
     this._setContentPlayheadTrackerEventsEnabled(false);
     this._setVideoEndedCallbackEnabled(false);
     this._nextPromise = null;
@@ -557,9 +556,15 @@ export default class Ima extends BasePlugin {
    * @returns {void}
    */
   _resizeAd() {
-    if (this._sdk && this._adsManager) {
+    if (this._sdk && this._adsManager && this._currentAd) {
       let viewMode = (this.player.isFullscreen() ? this._sdk.ViewMode.FULLSCREEN : this._sdk.ViewMode.NORMAL);
+      if (this._currentAd.isLinear()) {
         this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
+      } else {
+        this._adsContainerDiv.style.bottom = this._currentAd.getHeight() + 8 + 'px';
+        this._adsContainerDiv.style.left = (this.player.dimensions.width - this._currentAd.getWidth()) / 2 + 'px';
+        this._adsManager.resize(this._currentAd.getWidth() + 8, this._currentAd.getHeight() + 8, viewMode);
+      }
     }
   }
 
@@ -845,32 +850,6 @@ export default class Ima extends BasePlugin {
         this._isAdsCoverActive = false;
       }
     }
-  }
-
-  /**
-   * Toggle play/pause when click on the ads container.
-   * Relevant only for overlay ads.
-   * @param {boolean} enable - Whether to add or remove the listener.
-   * @private
-   * @returns {void}
-   */
-  _setTogglePlayPauseOnAdsContainerEnabled(enable: boolean): void {
-    if (this._adsContainerDiv && this._togglePlayPauseOnAdsContainerCallback) {
-      if (enable) {
-        this._adsContainerDiv.addEventListener("click", this._togglePlayPauseOnAdsContainerCallback);
-      } else {
-        this._adsContainerDiv.removeEventListener("click", this._togglePlayPauseOnAdsContainerCallback);
-      }
-    }
-  }
-
-  /**
-   * On ads container click handler.
-   * @private
-   * @returns {void}
-   */
-  _onAdsContainerClicked(): void {
-    this.player.paused ? this.player.play() : this.player.pause();
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -479,6 +479,8 @@ export default class Ima extends BasePlugin {
     this._adsCoverDiv.onclick = () => this._onAdsCoverClicked();
     // Append the ads container to the dom
     Utils.Dom.appendChild(playerView, this._adsContainerDiv);
+    // Hides the ads container after appending it to the DOM
+    this._hideAdsContainer();
     this._adDisplayContainer = new this._sdk.AdDisplayContainer(this._adsContainerDiv, this.player.getVideoElement());
   }
 
@@ -557,7 +559,7 @@ export default class Ima extends BasePlugin {
   _resizeAd() {
     if (this._sdk && this._adsManager) {
       let viewMode = (this.player.isFullscreen() ? this._sdk.ViewMode.FULLSCREEN : this._sdk.ViewMode.NORMAL);
-      this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
+        this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Also fixes issue when tap on Ad and return to player, the playback doesn't resumed on iPhone.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
