### PR TITLE
fix(FEC-8129): playback starts while ad is playing if only adsResponse is configured

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -347,8 +347,9 @@ export default class Ima extends BasePlugin {
       this._nextPromise = Utils.Object.defer();
       this._adDisplayContainer.initialize();
       this._hasUserAction = true;
-      if (!this.config.adTagUrl) {
+      if (!this.config.adTagUrl && !this.config.adsResponse) {
         this._resolveNextPromise();
+        return this._nextPromise;
       }
       if (this._isAdsManagerLoaded) {
         this.logger.debug("User action occurred after ads manager loaded");


### PR DESCRIPTION
### Description of the Changes

Check also for adsResponse 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
