### PR TITLE
fix(FEC-8092): playback start while ad is playing when calling play on ad completed

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -59,7 +59,7 @@ export default class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_BREAK_END,
-          from: [State.IDLE, State.LOADED],
+          from: [State.IDLE, State.PLAYING, State.LOADED],
           to: State.IDLE
         },
         {

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -50,8 +50,7 @@ export default class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_COMPLETED,
-          from: State.PLAYING,
-          to: State.IDLE
+          from: State.PLAYING
         },
         {
           name: context.player.Event.ALL_ADS_COMPLETED,


### PR DESCRIPTION
### Description of the Changes

Change the plugin state to IDLE only when ad break end.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
