### PR TITLE
fix(FEC-8131): skippable ads fail on iOS

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,15 +10,15 @@ const isMacOS = /^darwin/.test(process.platform);
 const customLaunchers = {
   Chrome_travis_ci: {
     base: 'Chrome',
-    flags: ['--no-sandbox']
+    flags: ['--no-sandbox', '--disable-autoplay-policy']
   }
 };
 
 module.exports = function (config) {
   let karmaConf = {
     logLevel: config.LOG_INFO,
-    browserDisconnectTimeout:30000,    
-    browserNoActivityTimeout:60000,
+    browserDisconnectTimeout: 30000,
+    browserNoActivityTimeout: 60000,
     browsers: [
       'Chrome',
       'Firefox'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ const isMacOS = /^darwin/.test(process.platform);
 const customLaunchers = {
   Chrome_travis_ci: {
     base: 'Chrome',
-    flags: ['--no-sandbox', '--disable-autoplay-policy']
+    flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required']
   }
 };
 

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -24,7 +24,7 @@ export default class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_STARTED,
-          from: [State.LOADED, State.IDLE, State.PAUSED],
+          from: [State.LOADED, State.IDLE, State.PAUSED, State.PLAYING],
           to: (adEvent: any): string => {
             let ad = adEvent.getAd();
             if (!ad.isLinear()) {
@@ -69,7 +69,7 @@ export default class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_LOADED,
-          from: [State.IDLE, State.LOADED]
+          from: [State.IDLE, State.LOADED, State.PLAYING]
         },
         {
           name: context.player.Event.AD_FIRST_QUARTILE,


### PR DESCRIPTION
### Description of the Changes

Add `delayInitUntilSourceSelected` flag which will prevent initialisation of the plugin until source selected.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
