### PR TITLE
fix(FEC-8142): overlay ad clickthrough doesn't work

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -143,7 +143,7 @@ export default class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  Utils.Dom.setAttribute(this._adsContainerDiv, 'data-ad-type', getAdType(adEvent));
+  Utils.Dom.setAttribute(this._adsContainerDiv, 'data-adtype', getAdType(adEvent));
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
   if (this._adsManager.isCustomPlaybackUsed()) {

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -6,12 +6,6 @@ import AdType from './ad-type'
 import {Utils} from 'playkit-js';
 
 /**
- * The overlay ad class.
- * @type {string}
- * @const
- */
-const OVERLAY_AD_CLASS: string = "playkit-overlay-ad";
-/**
  * Finite state machine for ima plugin.
  * @classdesc
  */
@@ -149,6 +143,7 @@ export default class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
+  Utils.Dom.setAttribute(this._adsContainerDiv, 'data-adType', getAdType(adEvent));
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
   if (this._adsManager.isCustomPlaybackUsed()) {
@@ -170,7 +165,6 @@ function onAdStarted(options: Object, adEvent: any): void {
   this._showAdsContainer();
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {
-    Utils.Dom.addClassName(this._adsContainerDiv, OVERLAY_AD_CLASS);
     this._setContentPlayheadTrackerEventsEnabled(true);
     this._setVideoEndedCallbackEnabled(true);
     if (this._nextPromise) {

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -143,7 +143,7 @@ export default class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  Utils.Dom.setAttribute(this._adsContainerDiv, 'data-adType', getAdType(adEvent));
+  Utils.Dom.setAttribute(this._adsContainerDiv, 'data-ad-type', getAdType(adEvent));
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
   if (this._adsManager.isCustomPlaybackUsed()) {

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -3,7 +3,14 @@ import StateMachine from 'javascript-state-machine'
 import StateMachineHistory from 'javascript-state-machine/lib/history'
 import State from './state'
 import AdType from './ad-type'
+import {Utils} from 'playkit-js';
 
+/**
+ * The overlay ad class.
+ * @type {string}
+ * @const
+ */
+const OVERLAY_AD_CLASS: string = "playkit-overlay-ad";
 /**
  * Finite state machine for ima plugin.
  * @classdesc
@@ -163,6 +170,7 @@ function onAdStarted(options: Object, adEvent: any): void {
   this._showAdsContainer();
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {
+    Utils.Dom.addClassName(this._adsContainerDiv, OVERLAY_AD_CLASS);
     this._setContentPlayheadTrackerEventsEnabled(true);
     this._setVideoEndedCallbackEnabled(true);
     if (this._nextPromise) {


### PR DESCRIPTION
### Description of the Changes

add ad type data attribute to the ads container
related to https://github.com/kaltura/playkit-js-ui/pull/228

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
