### PR TITLE
fix(FEC-7406): preroll doesn't played on change media while unmute the previous media

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -236,11 +236,10 @@ function onAdCompleted(options: Object, adEvent: any): void {
  */
 function onAllAdsCompleted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  onAdBreakEnd.call(this, options, adEvent);
   if (this._adsManager.isCustomPlaybackUsed() && this._contentComplete) {
     this.player.getVideoElement().src = this._contentSrc;
   }
-  this.destroy();
+  onAdBreakEnd.call(this, options, adEvent);
 }
 
 /**


### PR DESCRIPTION
### Description of the Changes

No need to destroy the plugin when ALL_ADS_COMPLETED is triggered.
Most of the destroy actions are already done on:
AD_COMPLETED
AD_BREAK_END

which been called before ALL_ADS_COMPLETED.

The destroy do in addition eventManager.destroy which remove all listeners and when we are unmuting the media we are not updating the ads manager's volume.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
