### PR TITLE
fix(FEC-8239): IMA exception when calling reset followed by destroy

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -569,6 +569,10 @@ export default class Ima extends BasePlugin {
         this._adsLoader.requestAds(adsRequest);
       } else if (playerWillAutoPlay) {
         getCapabilities(EngineType.HTML5).then(capabilities => {
+          // If the plugin has been destroyed while calling this promise
+          // the adsLoader will no longer exists
+          if (!this._adsLoader) return;
+
           if (capabilities.autoplay) {
             adsRequest.setAdWillAutoPlay(true);
           }


### PR DESCRIPTION
### Description of the Changes

If the plugin has been destroyed while calling the promise in reset the adsLoader will no longer exists so we need to add protection.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
