### PR TITLE
feat(FEC-8295): Show error UI on network error while playing ads

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -2,7 +2,7 @@
 import ImaMiddleware from './ima-middleware';
 import ImaStateMachine from './ima-state-machine';
 import State from './state';
-import {BaseMiddleware, BasePlugin, EngineType, getCapabilities, Utils} from 'playkit-js';
+import {BaseMiddleware, BasePlugin, EngineType, getCapabilities, Utils, Error} from 'playkit-js';
 import './assets/style.css';
 
 /**
@@ -386,6 +386,11 @@ export default class Ima extends BasePlugin {
       let selectedSource = event.payload.selectedSource;
       if (selectedSource && selectedSource.length > 0) {
         this._contentSrc = selectedSource[0].url;
+      }
+    });
+    this.eventManager.listen(this.player, this.player.Event.ERROR, event => {
+      if (event.payload && event.payload.severity === Error.Severity.CRITICAL) {
+        this.destroy();
       }
     });
   }

--- a/src/ima.js
+++ b/src/ima.js
@@ -390,7 +390,7 @@ export default class Ima extends BasePlugin {
     });
     this.eventManager.listen(this.player, this.player.Event.ERROR, event => {
       if (event.payload && event.payload.severity === Error.Severity.CRITICAL) {
-        this.destroy();
+        this.reset();
       }
     });
   }

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -442,10 +442,10 @@ describe('Ima Plugin', function() {
     player.play();
   });
 
-  it('should be destroyed on a critical error', done => {
+  it('should be reset on a critical error', done => {
     player = loadPlayerWithAds(targetId, {});
     ima = player._pluginManager.get('ima');
-    const spy = sinon.spy(ima, 'destroy');
+    const spy = sinon.spy(ima, 'reset');
     player.addEventListener(player.Event.ERROR, () => {
       spy.should.calledOnce;
       done();

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -1,5 +1,6 @@
 import {loadPlayerWithAds, maybeDoneTest, loadGPT, registerCompanionSlots} from './helpers';
 import * as TestUtils from 'playkit-js/test/src/utils/test-utils';
+import {FakeEvent} from 'playkit-js';
 // eslint-disable-next-line no-unused-vars
 import Ima from '../../src/ima';
 import AdType from '../../src/ad-type';
@@ -439,5 +440,16 @@ describe('Ima Plugin', function() {
       done();
     });
     player.play();
+  });
+
+  it('should be destroyed on a critical error', done => {
+    player = loadPlayerWithAds(targetId, {});
+    ima = player._pluginManager.get('ima');
+    const spy = sinon.spy(ima, 'destroy');
+    player.addEventListener(player.Event.ERROR, () => {
+      spy.should.calledOnce;
+      done();
+    });
+    player.dispatchEvent(new FakeEvent(player.Event.ERROR, {severity: 2}));
   });
 });


### PR DESCRIPTION
fix(FEC-8352): DRM and IMA on http, the ad is playing but after the ad there is a black screen

### Description of the Changes

Reset ima plugin on a critical error

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
