### PR TITLE
 fix(FEC-8517): don't preload ad on reset

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,6 @@
 .*/node_modules
 [include]
 [libs]
-node_modules/playkit-js/flow-typed/
+node_modules/@playkit-js/playkit-js/flow-typed/
 [options]
 unsafe.enable_getters_and_setters=true

--- a/flow-typed/modules/playkit-js.js
+++ b/flow-typed/modules/playkit-js.js
@@ -1,4 +1,4 @@
 // @flow
-declare module 'playkit-js' {
+declare module '@playkit-js/playkit-js' {
   declare module.exports: any;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "javascript-state-machine": "^3.0.1"
   },
   "devDependencies": {
+    "@playkit-js/playkit-js": "^0.36.0-canary.60cf482",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -63,7 +64,6 @@
     "lint-staged": "7.0.5",
     "mocha": "^3.2.0",
     "mocha-cli": "^1.0.1",
-    "playkit-js": "https://github.com/kaltura/playkit-js.git#master",
     "prettier": "^1.12.1",
     "sinon": "^2.0.0",
     "sinon-chai": "^2.8.0",
@@ -74,7 +74,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "playkit-js": "https://github.com/kaltura/playkit-js.git#master"
+    "@playkit-js/playkit-js": "^0.36.0-canary.60cf482"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "javascript-state-machine": "^3.0.1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "^0.36.0-canary.60cf482",
+    "@playkit-js/playkit-js": "^0.36.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",

--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -1,5 +1,5 @@
 // @flow
-import {BaseMiddleware} from 'playkit-js';
+import {BaseMiddleware} from '@playkit-js/playkit-js';
 import {Ima} from './ima';
 import {State} from './state';
 

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -3,7 +3,7 @@ import StateMachine from 'javascript-state-machine';
 import StateMachineHistory from 'javascript-state-machine/lib/history';
 import {State} from './state';
 import {AdType} from './ad-type';
-import {Utils} from 'playkit-js';
+import {Utils} from '@playkit-js/playkit-js';
 
 /**
  * Finite state machine for ima plugin.

--- a/src/ima.js
+++ b/src/ima.js
@@ -298,17 +298,9 @@ class Ima extends BasePlugin {
     if (this._adsLoader && !this._contentComplete) {
       this._adsLoader.contentComplete();
     }
+    this._stateMachine.goto(State.DONE);
     this._initMembers();
     this._addBindings();
-    if (!this._adsLoader) {
-      this._initAdsLoader();
-    }
-    this._requestAds();
-    if (this.config.adTagUrl) {
-      this._stateMachine.loaded();
-    } else {
-      this._stateMachine.goto(State.DONE);
-    }
   }
 
   /**
@@ -393,6 +385,11 @@ class Ima extends BasePlugin {
         this.reset();
       }
     });
+    this.eventManager.listenOnce(this.player, this.player.Event.CHANGE_SOURCE_STARTED, () => {
+      this.loadPromise.then(() => {
+        this._requestAds();
+      });
+    });
   }
 
   /**
@@ -429,9 +426,9 @@ class Ima extends BasePlugin {
         this.logger.debug('IMA SDK version: ' + this._sdk.VERSION);
         this._initImaSettings();
         this._initAdsContainer();
-        this._initAdsLoader();
-        this._requestAds();
-        this._stateMachine.loaded();
+        if (!this._adsLoader) {
+          this._initAdsLoader();
+        }
         this.loadPromise.resolve();
       })
       .catch(e => {
@@ -586,6 +583,7 @@ class Ima extends BasePlugin {
         adsRequest.setAdWillAutoPlay(false);
         this._adsLoader.requestAds(adsRequest);
       }
+      this._stateMachine.loaded();
     } else {
       this.logger.warn('Missing ad tag url: create plugin without requesting ads');
     }

--- a/src/ima.js
+++ b/src/ima.js
@@ -2,7 +2,7 @@
 import {ImaMiddleware} from './ima-middleware';
 import {ImaStateMachine} from './ima-state-machine';
 import {State} from './state';
-import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils} from 'playkit-js';
+import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils} from '@playkit-js/playkit-js';
 import './assets/style.css';
 
 /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -426,9 +426,7 @@ class Ima extends BasePlugin {
         this.logger.debug('IMA SDK version: ' + this._sdk.VERSION);
         this._initImaSettings();
         this._initAdsContainer();
-        if (!this._adsLoader) {
-          this._initAdsLoader();
-        }
+        this._initAdsLoader();
         this.loadPromise.resolve();
       })
       .catch(e => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {registerPlugin} from 'playkit-js';
+import {registerPlugin} from '@playkit-js/playkit-js';
 import {Ima} from './ima';
 
 declare var __VERSION__: string;

--- a/test/src/helpers.js
+++ b/test/src/helpers.js
@@ -1,4 +1,4 @@
-import loadPlayer from 'playkit-js';
+import loadPlayer from '@playkit-js/playkit-js';
 
 /**
  * @param {string} targetId _
@@ -8,6 +8,7 @@ import loadPlayer from 'playkit-js';
  */
 function loadPlayerWithAds(targetId, imaConfig, playbackConfig) {
   let config = {
+    logLevel: 'DEBUG',
     sources: {
       progressive: [
         {

--- a/test/src/helpers.js
+++ b/test/src/helpers.js
@@ -8,7 +8,6 @@ import loadPlayer from '@playkit-js/playkit-js';
  */
 function loadPlayerWithAds(targetId, imaConfig, playbackConfig) {
   let config = {
-    logLevel: 'DEBUG',
     sources: {
       progressive: [
         {

--- a/test/src/ima.api.spec.js
+++ b/test/src/ima.api.spec.js
@@ -1,5 +1,5 @@
 import {loadPlayerWithAds} from './helpers';
-import * as TestUtils from 'playkit-js/test/src/utils/test-utils';
+import * as TestUtils from '@playkit-js/playkit-js/test/src/utils/test-utils';
 // eslint-disable-next-line no-unused-vars
 import {Ima} from '../../src';
 

--- a/test/src/ima.api.spec.js
+++ b/test/src/ima.api.spec.js
@@ -1,5 +1,5 @@
 import {loadPlayerWithAds} from './helpers';
-import * as TestUtils from '@playkit-js/playkit-js/test/src/utils/test-utils';
+import * as TestUtils from './utils/test-utils';
 // eslint-disable-next-line no-unused-vars
 import {Ima} from '../../src';
 

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -206,7 +206,7 @@ describe('Ima Plugin', function() {
       maybeDoneTest(cuePoints, adPodIndex, done);
     });
     player.addEventListener(player.Event.LOADED_METADATA, () => {
-      // player.currentTime = player.duration - 1;
+      player.currentTime = player.duration - 1;
     });
     player.play();
   });

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -1,6 +1,6 @@
 import {loadPlayerWithAds, maybeDoneTest, loadGPT, registerCompanionSlots} from './helpers';
-import * as TestUtils from 'playkit-js/test/src/utils/test-utils';
-import {FakeEvent} from 'playkit-js';
+import * as TestUtils from '@playkit-js/playkit-js/test/src/utils/test-utils';
+import {FakeEvent} from '@playkit-js/playkit-js';
 // eslint-disable-next-line no-unused-vars
 import {Ima} from '../../src/ima';
 import {AdType} from '../../src/ad-type';

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -1,5 +1,5 @@
 import {loadPlayerWithAds, maybeDoneTest, loadGPT, registerCompanionSlots} from './helpers';
-import * as TestUtils from '@playkit-js/playkit-js/test/src/utils/test-utils';
+import * as TestUtils from './utils/test-utils';
 import {FakeEvent} from '@playkit-js/playkit-js';
 // eslint-disable-next-line no-unused-vars
 import {Ima} from '../../src/ima';
@@ -206,7 +206,7 @@ describe('Ima Plugin', function() {
       maybeDoneTest(cuePoints, adPodIndex, done);
     });
     player.addEventListener(player.Event.LOADED_METADATA, () => {
-      player.currentTime = player.duration - 1;
+      // player.currentTime = player.duration - 1;
     });
     player.play();
   });

--- a/test/src/utils/test-utils.js
+++ b/test/src/utils/test-utils.js
@@ -1,0 +1,45 @@
+/**
+ * Creates a dom element.
+ * @param {string} type - The element type.
+ * @param {string} id - The element id.
+ * @param {string} opt_parentId - Optional parent id.
+ * @returns {HTMLDivElement}
+ */
+function createElement(type, id, opt_parentId) {
+  let element = document.createElement(type);
+  element.id = id;
+  if (!opt_parentId) {
+    document.body.appendChild(element);
+  } else {
+    let parent = document.getElementById(opt_parentId);
+    if (parent) {
+      parent.appendChild(element);
+    } else {
+      document.body.appendChild(element);
+    }
+  }
+  return element;
+}
+
+/**
+ * Removes a dom element.
+ * @param {string} id - The element id.
+ * @returns {void}
+ */
+function removeElement(id) {
+  let element = document.getElementById(id);
+  element.parentNode.removeChild(element);
+}
+
+/**
+ * Removes all the video elements that created by the test from the document.
+ * @returns {void}
+ */
+function removeVideoElementsFromTestPage() {
+  let element = document.getElementsByTagName('video');
+  for (let i = element.length - 1; i >= 0; i--) {
+    element[i].parentNode.removeChild(element[i]);
+  }
+}
+
+export {removeVideoElementsFromTestPage, createElement, removeElement};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,9 +80,9 @@ module.exports = {
     modules: [path.resolve(__dirname, 'src'), 'node_modules']
   },
   externals: {
-    'playkit-js': {
-      commonjs: 'playkit-js',
-      commonjs2: 'playkit-js',
+    '@playkit-js/playkit-js': {
+      commonjs: '@playkit-js/playkit-js',
+      commonjs2: '@playkit-js/playkit-js',
       amd: 'playkit-js',
       root: ['KalturaPlayer', 'core']
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@^0.36.0-canary.60cf482":
-  version "0.36.0-canary.60cf482"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.36.0-canary.60cf482.tgz#60c97fbfe5d32f5522a6f2cd878d81307a1b6761"
+"@playkit-js/playkit-js@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.36.0.tgz#c13ea1758b724f1434c1cfee8f043045362de550"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@playkit-js/playkit-js@^0.36.0-canary.60cf482":
+  version "0.36.0-canary.60cf482"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.36.0-canary.60cf482.tgz#60c97fbfe5d32f5522a6f2cd878d81307a1b6761"
+  dependencies:
+    js-logger "^1.3.0"
+    ua-parser-js "^0.7.13"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -5180,13 +5187,6 @@ pkg-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
-
-"playkit-js@https://github.com/kaltura/playkit-js.git#master":
-  version "0.34.0"
-  resolved "https://github.com/kaltura/playkit-js.git#366eb141a45d910fbf8a0c4fe5fe35d4c896bb20"
-  dependencies:
-    js-logger "^1.3.0"
-    ua-parser-js "^0.7.13"
 
 please-upgrade-node@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### Description of the Changes

IMA plugin loads next ad on reset, but reset can also be called when app just wants to stop current playback but not change media to next one.

fixes FEC-8517

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
