### PR TITLE
fix(FEC-8599): ads counter is not running when any ad playing

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -856,7 +856,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._intervalTimer = setInterval(() => {
       if (this._stateMachine.is(State.PLAYING)) {
         let remainingTime = this._adsManager.getRemainingTime();
-        let duration = this._adsManager.getCurrentAd().getDuration();
+        let duration = this._currentAd.getDuration();
         let currentTime = duration - remainingTime;
         if (Utils.Number.isNumber(duration) && Utils.Number.isNumber(currentTime)) {
           this.dispatchEvent(this.player.Event.AD_PROGRESS, {


### PR DESCRIPTION
ima returns a null for .getCurrentAd().
changed it to - _currentAd.getDuration();

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
