### PR TITLE
fix: add LOADED transition to AD_CAN_SKIP event

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -104,7 +104,7 @@ class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_CAN_SKIP,
-          from: [State.PLAYING, State.PAUSED]
+          from: [State.PLAYING, State.PAUSED, State.LOADED]
         },
         {
           name: 'goto',


### PR DESCRIPTION
### Description of the Changes

Add another transition to AD_CAN_SKIP event which it can now be triggered from LOADED state.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
