### PR TITLE
fix(FEC-8762): destroy is called incorrectly in plugin life cycle

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -83,7 +83,7 @@ class ImaMiddleware extends BaseMiddleware {
         }
       })
       .catch(e => {
-        this._context.destroy();
+        this._context.reset();
         this._context.logger.error(e);
         this.callNext(next);
       });

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -321,11 +321,11 @@ function onAdError(options: Object, adEvent: any): void {
   if (adEvent.type === 'adError') {
     this.logger.debug(adEvent.type.toUpperCase());
     let adError = adEvent.getError();
-    if (this.loadPromise) {
-      this.loadPromise.reject(adError);
-    }
+    //if this is autoplay or user already requested play then next promise will handle reset
     if (this._nextPromise) {
       this._nextPromise.reject(adError);
+    } else {
+      this.reset();
     }
     this.dispatchEvent(options.transition, getAdError(adError, true));
   } else {

--- a/test/src/ima-middleware.spec.js
+++ b/test/src/ima-middleware.spec.js
@@ -31,7 +31,7 @@ describe('Ima Middleware', function() {
     pauseAd: function() {
       return Promise.resolve();
     },
-    destroy: function() {},
+    reset: function() {},
     logger: {
       error: function() {},
       debug: function() {}
@@ -60,7 +60,7 @@ describe('Ima Middleware', function() {
     });
 
     it('should destory adsManager and resume playback in case of error', function(done) {
-      let spy = sandbox.spy(fakeContext, 'destroy');
+      let spy = sandbox.spy(fakeContext, 'reset');
       fakeContext.setCurrentState(State.LOADED);
       fakeContext.initialUserAction = Promise.reject();
       imaMiddleware = new ImaMiddleware(fakeContext);
@@ -88,8 +88,8 @@ describe('Ima Middleware', function() {
       });
     });
 
-    it('should destroy', function(done) {
-      let spy1 = sandbox.spy(fakeContext, 'destroy');
+    it('should reset', function(done) {
+      let spy1 = sandbox.spy(fakeContext, 'reset');
       let spy2 = sandbox.spy(fakeContext.logger, 'error');
       fakeContext.loadPromise = Promise.reject();
       imaMiddleware = new ImaMiddleware(fakeContext);


### PR DESCRIPTION
### Description of the Changes

in addition to #82 this PR will handle wrongful event manager destroying and in general will prevent calling the destroy from within the plugin cause this means that plugin should not be used anymore, while we only want to reset it until next media will be played.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
