### PR TITLE
fix(FEC-8740): VPAID is still defaulting to ENABLED

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -571,11 +571,11 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   /**
    * Gets the vpaid mode.
    * @private
-   * @returns {string} - The vpaid mode.
+   * @returns {number} - The vpaid mode.
    * @instance
    * @memberof Ima
    */
-  _getVpaidMode(): string {
+  _getVpaidMode(): number {
     const vpaidmode = this._sdk.ImaSdkSettings.VpaidMode[this.config.vpaidMode];
     if (this.config.vpaidMode && typeof vpaidmode === 'number') {
       this.logger.debug('VpaidMode: set to ' + this.config.vpaidMode);

--- a/src/ima.js
+++ b/src/ima.js
@@ -576,7 +576,14 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _getVpaidMode(): string {
-    return this.config.vpaidMode || this._sdk.ImaSdkSettings.VpaidMode.ENABLED;
+    const vpaidmode = this._sdk.ImaSdkSettings.VpaidMode[this.config.vpaidMode];
+    if (this.config.vpaidMode && typeof vpaidmode === 'number') {
+      this.logger.debug('VpaidMode: set to ' + this.config.vpaidMode);
+      return vpaidmode;
+    } else {
+      this.logger.warn('VpaidMode is not set, setting to ENABLED');
+      return this._sdk.ImaSdkSettings.VpaidMode.ENABLED;
+    }
   }
 
   /**

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -449,4 +449,60 @@ describe('Ima Plugin', function() {
     });
     player.dispatchEvent(new FakeEvent(player.Event.ERROR, {severity: 2}));
   });
+
+  it('should return the correct vpaid for INSECURE', function(done) {
+    player = loadPlayerWithAds(targetId, {
+      vpaidMode: 'INSECURE',
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]'
+    });
+    ima = player._pluginManager.get('ima');
+    ima.loadPromise.then(function() {
+      const value = ima._getVpaidMode();
+      value.should.equals(2);
+      done();
+    });
+  });
+
+  it('should return the correct vpaid for ENABLED', function(done) {
+    player = loadPlayerWithAds(targetId, {
+      vpaidMode: 'ENABLED',
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]'
+    });
+    ima = player._pluginManager.get('ima');
+    ima.loadPromise.then(function() {
+      const value = ima._getVpaidMode();
+      value.should.equals(1);
+      done();
+    });
+  });
+
+  it('should return the correct vpaid for DISABLED', function(done) {
+    player = loadPlayerWithAds(targetId, {
+      vpaidMode: 'DISABLED',
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]'
+    });
+    ima = player._pluginManager.get('ima');
+    ima.loadPromise.then(function() {
+      const value = ima._getVpaidMode();
+      value.should.equals(0);
+      done();
+    });
+  });
+
+  it('should return the correct vpaid for ENABLED', function(done) {
+    player = loadPlayerWithAds(targetId, {
+      vpaidMode: '',
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]'
+    });
+    ima = player._pluginManager.get('ima');
+    ima.loadPromise.then(function() {
+      const value = ima._getVpaidMode();
+      value.should.equals(1);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Fixed the VPAIDmode regression

1. Added the 'vpaidmode' const which will check if the selected VPAID mode config is defined correctly, and will pass it as a number.

Logged the selected VPAID mode to the console.

2. Will default to 'ENABLED' when VPAID mode is not set, or written incorrectly.

Warn the user that VPAID is defaulting to 'ENABLED' 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
