### PR TITLE
feat(FEC-8749): expose IMA ad data

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "javascript-state-machine": "^3.0.1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "^0.37.0",
+    "@playkit-js/playkit-js": "^0.45.0-canary.67d8db1",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -77,7 +77,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "^0.37.0"
+    "@playkit-js/playkit-js": "^0.45.0-canary.67d8db1"
   },
   "repository": {
     "type": "git",

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -192,7 +192,9 @@ function onAdStarted(options: Object, adEvent: any): void {
     this._setContentPlayheadTrackerEventsEnabled(false);
     this._startAdInterval();
   }
-  this.dispatchEvent(options.transition);
+  const adOptions = getAdOptions(adEvent);
+  const ad = new Ad(adEvent.getAd().getAdId(), adOptions);
+  this.dispatchEvent(options.transition, {ad});
 }
 
 /**
@@ -446,13 +448,16 @@ function getAdOptions(adEvent: any): Object {
   const adData = adEvent.getAdData();
   const podInfo = ad.getAdPodInfo();
   adOptions.url = ad.getMediaUrl();
-  adOptions.clickThroughUrl = adData.clickThroughUrl;
+  adOptions.clickThroughUrl = adData && adData.clickThroughUrl;
   adOptions.contentType = ad.getContentType();
   adOptions.duration = ad.getDuration();
   adOptions.position = podInfo.getAdPosition();
   adOptions.title = ad.getTitle();
   adOptions.linear = ad.isLinear();
   adOptions.skipOffset = ad.getSkipTimeOffset();
+  adOptions.width = ad.isLinear() ? ad.getVastMediaWidth() : ad.getWidth();
+  adOptions.height = ad.isLinear() ? ad.getVastMediaHeight() : ad.getHeight();
+  adOptions.bitrate = ad.getVastMediaBitrate();
   return adOptions;
 }
 

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -101,6 +101,35 @@ describe('Ima Plugin', function() {
     player.play();
   });
 
+  it('should sent the ad data - linear', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl:
+        '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator='
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_STARTED, e => {
+      e.payload.ad.width.should.gt(0);
+      e.payload.ad.height.should.gt(0);
+      e.payload.ad.bitrate.should.gt(0);
+      done();
+    });
+    player.play();
+  });
+
+  it('should sent the ad data - non-linear', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl:
+        '//pubads.g.doubleclick.net/gampad/ads?sz=480x70&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinear&correlator='
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_STARTED, e => {
+      e.payload.ad.width.should.gt(0);
+      e.payload.ad.height.should.gt(0);
+      done();
+    });
+    player.play();
+  });
+
   it('should support setting adsRenderingSettings config object', done => {
     player = loadPlayerWithAds(targetId, {
       adTagUrl:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@^0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.37.0.tgz#2249594fc04becd4c9bc0a6d171077a0b5d40823"
+"@playkit-js/playkit-js@^0.45.0-canary.67d8db1":
+  version "0.45.0-canary.67d8db1"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.45.0-canary.67d8db1.tgz#26f1f2bc38158f3ed239f2afca3022e386b3f8cd"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

* calculate the ad data according the ad type
* send the ad as a payload of `AD_STARTED` event - when the ad data exists.

Depends on https://github.com/kaltura/playkit-js/pull/334

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
