### PR TITLE
feat(FEC-8675): add ad progress and buffer event to player

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -107,6 +107,14 @@ class ImaStateMachine {
           from: [State.PLAYING, State.PAUSED, State.LOADED]
         },
         {
+          name: context.player.Event.AD_PROGRESS,
+          from: [State.PLAYING, State.PAUSED]
+        },
+        {
+          name: context.player.Event.AD_BUFFERING,
+          from: [State.PLAYING, State.PAUSED]
+        },
+        {
           name: 'goto',
           from: '*',
           to: s => s
@@ -131,6 +139,8 @@ class ImaStateMachine {
         onUserclosedad: onAdEvent.bind(context),
         onAdvolumechanged: onAdEvent.bind(context),
         onAdmuted: onAdEvent.bind(context),
+        onAdprogress: onAdProgress.bind(context),
+        onAdbuffering: onAdEvent.bind(context),
         onEnterState: onEnterState.bind(context),
         onPendingTransition: onPendingTransition.bind(context)
       },
@@ -190,7 +200,6 @@ function onAdStarted(options: Object, adEvent: any): void {
     }
   } else {
     this._setContentPlayheadTrackerEventsEnabled(false);
-    this._startAdInterval();
   }
   this.dispatchEvent(options.transition);
 }
@@ -243,9 +252,6 @@ function onAdResumed(options: Object, adEvent: any): void {
  */
 function onAdCompleted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  if (this._currentAd.isLinear()) {
-    this._stopAdInterval();
-  }
   this._currentAd = null;
   this.dispatchEvent(options.transition);
 }
@@ -349,7 +355,6 @@ function onAdError(options: Object, adEvent: any): void {
  */
 function onAdSkipped(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  this._stopAdInterval();
   this.dispatchEvent(options.transition);
 }
 
@@ -365,6 +370,29 @@ function onAdCanSkip(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._adsManager.getAdSkippableState()) {
     this.dispatchEvent(options.transition);
+  }
+}
+
+/**
+ * AD_PROGRESS event handler.
+ * @param {Object} options - fsm event data.
+ * @param {any} adEvent - ima event data.
+ * @returns {void}
+ * @private
+ * @memberof ImaStateMachine
+ */
+function onAdProgress(options: Object, adEvent: any): void {
+  this.logger.debug(adEvent.type.toUpperCase());
+  const remainingTime = this._adsManager.getRemainingTime();
+  const duration = this._currentAd.getDuration();
+  const currentTime = duration - remainingTime;
+  if (Utils.Number.isNumber(duration) && Utils.Number.isNumber(currentTime)) {
+    this.dispatchEvent(options.transition, {
+      adProgress: {
+        currentTime: currentTime,
+        duration: duration
+      }
+    });
   }
 }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -161,13 +161,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _contentComplete: boolean;
   /**
-   * The ad interval timer.
-   * @member
-   * @private
-   * @memberof Ima
-   */
-  _intervalTimer: ?number;
-  /**
    * Video current time before ads.
    * On custom playback when only one video tag playing, save the video current time.
    * @member
@@ -344,7 +337,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   reset(): void {
     this.logger.debug('reset');
     this.eventManager.removeAll();
-    this._stopAdInterval();
     this._hideAdsContainer();
     if (!this._isImaSDKLibLoaded()) {
       return;
@@ -371,7 +363,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   destroy(): void {
     this.logger.debug('destroy');
     this.eventManager.destroy();
-    this._stopAdInterval();
     this._hideAdsContainer();
     if (this._adsManager) {
       this._adsManager.destroy();
@@ -471,7 +462,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adsManager = null;
     this._contentComplete = false;
     this._isAdsManagerLoaded = false;
-    this._intervalTimer = null;
     this._videoLastCurrentTime = null;
     this._contentPlayheadTracker = {currentTime: 0, previousTime: 0, seeking: false, duration: 0};
     this._hasUserAction = false;
@@ -948,6 +938,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.USER_CLOSE, adEvent => this._stateMachine.userclosedad(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.VOLUME_CHANGED, adEvent => this._stateMachine.advolumechanged(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.VOLUME_MUTED, adEvent => this._stateMachine.admuted(adEvent));
+    this._adsManager.addEventListener(this._sdk.AdEvent.Type.AD_PROGRESS, adEvent => this._stateMachine.adprogress(adEvent));
+    this._adsManager.addEventListener(this._sdk.AdEvent.Type.AD_BUFFERING, adEvent => this._stateMachine.adbuffering(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.LOG, adEvent => this._stateMachine.aderror(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.SKIPPABLE_STATE_CHANGED, adEvent => this._stateMachine.adcanskip(adEvent));
     this._adsManager.addEventListener(this._sdk.AdErrorEvent.Type.AD_ERROR, adEvent => this._stateMachine.aderror(adEvent));
@@ -969,46 +961,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
           this._adsManager.setVolume(this.player.volume);
         }
       }
-    }
-  }
-
-  /**
-   * Starts ad interval timer.
-   * @private
-   * @returns {void}
-   * @instance
-   * @memberof Ima
-   */
-  _startAdInterval(): void {
-    this._stopAdInterval();
-    this._intervalTimer = setInterval(() => {
-      if (this._stateMachine.is(State.PLAYING)) {
-        let remainingTime = this._adsManager.getRemainingTime();
-        let duration = this._currentAd.getDuration();
-        let currentTime = duration - remainingTime;
-        if (Utils.Number.isNumber(duration) && Utils.Number.isNumber(currentTime)) {
-          this.dispatchEvent(this.player.Event.AD_PROGRESS, {
-            adProgress: {
-              currentTime: currentTime,
-              duration: duration
-            }
-          });
-        }
-      }
-    }, 300);
-  }
-
-  /**
-   * Stops ads interval timer.
-   * @private
-   * @returns {void}
-   * @instance
-   * @memberof Ima
-   */
-  _stopAdInterval(): void {
-    if (this._intervalTimer) {
-      clearInterval(this._intervalTimer);
-      this._intervalTimer = null;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

IMA latest version(3.254.0) adds support to ad buffering event:

Adds AdEvent.Type.AD_BUFFERING event. This event is fired when ad playback has stalled due to buffering

Version added AD_PROGRESS event:This event triggers throughout ad playback, and contains an AdProgressData object, obtained via getAdData().

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
