### PR TITLE
feat(FEC-8815): support vast timeout

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -63,7 +63,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       useStyledLinearAds: false,
       useStyledNonLinearAds: true,
       bitrate: -1,
-      autoAlign: true
+      autoAlign: true,
+      loadVideoTimeout: -1
     },
     companions: {
       ads: null,


### PR DESCRIPTION
Added ima' default timeout to the rendering configuration (-1 = 8 seconds)
The application can configure otherwise:
```
adsRenderingSettings: {
  loadVideoTimeout: 20
 }
```

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
