### PR TITLE
fix(FEC-8891): a bumper after an ad cannot be clicked

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -386,7 +386,7 @@ function onAdCanSkip(options: Object, adEvent: any): void {
 function onAdProgress(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   const remainingTime = this._adsManager.getRemainingTime();
-  const duration = this._currentAd.getDuration();
+  const duration = adEvent.getAdData() && adEvent.getAdData().duration;
   const currentTime = duration - remainingTime;
   if (Utils.Number.isNumber(duration) && Utils.Number.isNumber(currentTime)) {
     this.dispatchEvent(options.transition, {


### PR DESCRIPTION
### Description of the Changes

`this._currentAd` was `null`,
getting the `duration` from `adEvent.getAdData()`

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
