### PR TITLE
fix(FEC-8844): listen to the player resize event instead of the window's

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -438,7 +438,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _addBindings(): void {
     FULL_SCREEN_EVENTS.forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, () => this._resizeAd()));
-    this.eventManager.listen(window, 'resize', () => this._resizeAd());
+    this.eventManager.listen(this.player, 'resize', () => this._resizeAd());
     this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, event => {


### PR DESCRIPTION
### Description of the Changes

listen to the player resize event instead of the window's

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
