### PR TITLE
feat(FEC-8631): bumper plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,7 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="0.11.0"></a>
-# [0.11.0](https://github.com/kaltura/playkit-js-ima/compare/v0.10.1...v0.11.0) (2019-02-28)
-
-
-### Bug Fixes
-
-* **FEC-8844:** listen to the player resize event instead of the window's ([#95](https://github.com/kaltura/playkit-js-ima/issues/95)) ([9d77484](https://github.com/kaltura/playkit-js-ima/commit/9d77484))
-* **FEC-8891:** a bumper after an ad cannot be clicked ([#94](https://github.com/kaltura/playkit-js-ima/issues/94)) ([02e29db](https://github.com/kaltura/playkit-js-ima/commit/02e29db))
+# [0.11.0](https://github.com/kaltura/playkit-js-ima/compare/v0.10.3...v0.11.0) (2019-02-28)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.11.0"></a>
+# [0.11.0](https://github.com/kaltura/playkit-js-ima/compare/v0.10.1...v0.11.0) (2019-02-28)
+
+
+### Bug Fixes
+
+* **FEC-8844:** listen to the player resize event instead of the window's ([#95](https://github.com/kaltura/playkit-js-ima/issues/95)) ([9d77484](https://github.com/kaltura/playkit-js-ima/commit/9d77484))
+* **FEC-8891:** a bumper after an ad cannot be clicked ([#94](https://github.com/kaltura/playkit-js-ima/issues/94)) ([02e29db](https://github.com/kaltura/playkit-js-ima/commit/02e29db))
+
+
+### Features
+
+* **FEC-8631:** bumper plugin ([bfc41d9](https://github.com/kaltura/playkit-js-ima/commit/bfc41d9))
+
+
+
 <a name="0.10.3"></a>
 ## [0.10.3](https://github.com/kaltura/playkit-js-ima/compare/v0.10.2...v0.10.3) (2019-02-27)
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,12 +14,20 @@ const customLaunchers = {
   }
 };
 
+const launchers = {
+  Chrome_browser: {
+    base: 'Chrome',
+    flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required']
+  }
+};
+
 module.exports = function(config) {
   let karmaConf = {
     logLevel: config.LOG_INFO,
     browserDisconnectTimeout: 30000,
     browserNoActivityTimeout: 60000,
-    browsers: ['Chrome', 'Firefox'],
+    customLaunchers: launchers,
+    browsers: ['Chrome_browser', 'Firefox'],
     concurrency: 1,
     singleRun: true,
     colors: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/playkit-js-ima",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "main": "dist/playkit-ima.js",
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "^0.46.1",
+    "@playkit-js/playkit-js": "0.47.0-canary.173edfb",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -77,7 +77,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "^0.45.1-canary.4eaff16"
+    "@playkit-js/playkit-js": "0.47.0-canary.173edfb"
   },
   "repository": {
     "type": "git",

--- a/src/ima-ads-controller.js
+++ b/src/ima-ads-controller.js
@@ -42,6 +42,16 @@ class ImaAdsController implements IAdsPluginController {
   }
 
   /**
+   * On playback ended handler.
+   * @public
+   * @returns {Promise<void>} - complete promise
+   * @memberof ImaAdsController
+   */
+  onPlaybackEnded(): Promise<void> {
+    return this._context.onMediaEnded();
+  }
+
+  /**
    * Whether this ads controller is active
    * @public
    * @returns {boolean} - is active

--- a/src/ima-ads-controller.js
+++ b/src/ima-ads-controller.js
@@ -1,12 +1,13 @@
 // @flow
 import {Ima} from './ima';
+import {State} from './state';
 
 /**
  * Controller for ima plugin.
  * @class ImaAdsController
  * @param {Ima} context - The ima plugin context.
  */
-class ImaAdsController implements IAdsController {
+class ImaAdsController implements IAdsPluginController {
   /**
    * The plugin context.
    * @member
@@ -32,12 +33,32 @@ class ImaAdsController implements IAdsController {
   /**
    * Play an ad on demand.
    * @param {string} adTagUrl - The ad tag url to play.
-   * @private
+   * @public
    * @returns {void}
    * @memberof ImaAdsController
    */
   playAdNow(adTagUrl: string): void {
     this._context.playAdNow(adTagUrl);
+  }
+
+  /**
+   * Whether this ads controller is active
+   * @public
+   * @returns {boolean} - is active
+   * @memberof ImaAdsController
+   */
+  get active(): boolean {
+    return this._context.getStateMachine().state === State.PLAYING || this._context.getStateMachine().state === State.PAUSED;
+  }
+
+  /**
+   * Whether this ads controller is done
+   * @public
+   * @returns {boolean} - is done
+   * @memberof ImaAdsController
+   */
+  get done(): boolean {
+    return this._context.getStateMachine().state === State.DONE;
   }
 }
 

--- a/src/ima-ads-controller.js
+++ b/src/ima-ads-controller.js
@@ -48,7 +48,7 @@ class ImaAdsController implements IAdsPluginController {
    * @memberof ImaAdsController
    */
   onPlaybackEnded(): Promise<void> {
-    return this._context.onMediaEnded();
+    return this._context.onPlaybackEnded();
   }
 
   /**

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -188,7 +188,6 @@ function onAdStarted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   this._currentAd = adEvent.getAd();
   this._resizeAd();
-  this._showAdsContainer();
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {
     this._setContentPlayheadTrackerEventsEnabled(true);
@@ -199,6 +198,7 @@ function onAdStarted(options: Object, adEvent: any): void {
       this.player.play();
     }
   } else {
+    this._showAdsContainer();
     this._setContentPlayheadTrackerEventsEnabled(false);
   }
   const adOptions = getAdOptions(adEvent);

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -52,7 +52,7 @@ class ImaStateMachine {
           from: [State.PLAYING, State.PAUSED]
         },
         {
-          name: context.player.Event.ALL_ADS_COMPLETED,
+          name: context.player.Event.ADS_COMPLETED,
           from: [State.IDLE, State.PAUSED],
           to: State.DONE
         },
@@ -128,7 +128,7 @@ class ImaStateMachine {
         onAdclicked: onAdClicked.bind(context),
         onAdskipped: onAdSkipped.bind(context),
         onAdcompleted: onAdCompleted.bind(context),
-        onAlladscompleted: onAllAdsCompleted.bind(context),
+        onAdscompleted: onAdsCompleted.bind(context),
         onAdcanskip: onAdCanSkip.bind(context),
         onAdbreakstart: onAdBreakStart.bind(context),
         onAdbreakend: onAdBreakEnd.bind(context),
@@ -259,15 +259,15 @@ function onAdCompleted(options: Object, adEvent: any): void {
 }
 
 /**
- * ALL_ADS_COMPLETED event handler.
+ * ADS_COMPLETED event handler.
  * @param {Object} options - fsm event data.
  * @param {any} adEvent - ima event data.
  * @returns {void}
  * @private
  * @memberof ImaStateMachine
  */
-function onAllAdsCompleted(options: Object, adEvent: any): void {
-  this.logger.debug(adEvent.type.toUpperCase());
+function onAdsCompleted(options: Object, adEvent: any): void {
+  this.logger.debug(options.transition.toUpperCase());
   if (this._adsManager.isCustomPlaybackUsed() && this._contentComplete) {
     this.player.getVideoElement().src = this._contentSrc;
   }
@@ -498,6 +498,7 @@ function getAdOptions(adEvent: any): Object {
   adOptions.width = ad.isLinear() ? ad.getVastMediaWidth() : ad.getWidth();
   adOptions.height = ad.isLinear() ? ad.getVastMediaHeight() : ad.getHeight();
   adOptions.bitrate = ad.getVastMediaBitrate();
+  adOptions.bumper = podInfo.getIsBumper();
   return adOptions;
 }
 

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -192,7 +192,6 @@ function onAdStarted(options: Object, adEvent: any): void {
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {
     this._setContentPlayheadTrackerEventsEnabled(true);
-    this._setVideoEndedCallbackEnabled(true);
     if (this._nextPromise) {
       this._resolveNextPromise();
     } else {
@@ -287,7 +286,6 @@ function onAdBreakStart(options: Object, adEvent: any): void {
   this.player.pause();
   const adBreakOptions = getAdBreakOptions.call(this, adEvent);
   const adBreak = new AdBreak(adBreakOptions);
-  this._setVideoEndedCallbackEnabled(false);
   this._maybeForceExitFullScreen();
   this._maybeSaveVideoCurrentTime();
   this.dispatchEvent(options.transition, {adBreak: adBreak});
@@ -303,7 +301,6 @@ function onAdBreakStart(options: Object, adEvent: any): void {
  */
 function onAdBreakEnd(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  this._setVideoEndedCallbackEnabled(true);
   this._setContentPlayheadTrackerEventsEnabled(true);
   this._currentAd = null;
   if (!this._contentComplete) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -544,6 +544,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this._showAdsContainer();
       }
     });
+    this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._onMediaEnded());
   }
 
   /**
@@ -917,18 +918,29 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
 
   /**
    * Ended event handler.
+   * @private
+   * @returns {void}
+   * @instance
+   * @memberof Ima
+   */
+  _onMediaEnded(): void {
+    this.logger.debug('Media ended');
+    this._contentComplete = true;
+    if (this._currentAd && !this._currentAd.isLinear()) {
+      this.reset();
+    }
+  }
+
+  /**
+   * Ended event handler.
    * @public
    * @returns {Promise<void>} - complete promise
    * @instance
    * @memberof Ima
    */
-  onMediaEnded(): Promise<void> {
-    this.logger.debug('Media ended');
+  onPlaybackEnded(): Promise<void> {
+    this.logger.debug('Playback ended');
     this._adsLoader.contentComplete();
-    this._contentComplete = true;
-    if (this._currentAd && !this._currentAd.isLinear()) {
-      this.reset();
-    }
     if (this._adsManager && this._adsManager.getCuePoints().includes(-1)) {
       return new Promise(resolve => {
         this.eventManager.listenOnce(this._adsManager, this._sdk.AdEvent.Type.ALL_ADS_COMPLETED, () => {

--- a/src/ima.js
+++ b/src/ima.js
@@ -452,6 +452,11 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.reset();
       }
     });
+    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => {
+      if (this._currentAd && !this._currentAd.isLinear()) {
+        this._showAdsContainer();
+      }
+    });
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -947,7 +947,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.SKIPPED, adEvent => this._stateMachine.adskipped(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.COMPLETE, adEvent => this._stateMachine.adcompleted(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.CONTENT_RESUME_REQUESTED, adEvent => this._stateMachine.adbreakend(adEvent));
-    this._adsManager.addEventListener(this._sdk.AdEvent.Type.ALL_ADS_COMPLETED, adEvent => this._stateMachine.alladscompleted(adEvent));
+    this._adsManager.addEventListener(this._sdk.AdEvent.Type.ALL_ADS_COMPLETED, adEvent => this._stateMachine.adscompleted(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.USER_CLOSE, adEvent => this._stateMachine.userclosedad(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.VOLUME_CHANGED, adEvent => this._stateMachine.advolumechanged(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.VOLUME_MUTED, adEvent => this._stateMachine.admuted(adEvent));

--- a/src/ima.js
+++ b/src/ima.js
@@ -318,11 +318,11 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   /**
    * Gets the ads controller.
    * @public
-   * @returns {IAdsController} - The ads api.
+   * @returns {IAdsPluginController} - The ads api.
    * @instance
    * @memberof Ima
    */
-  getAdsController(): IAdsController {
+  getAdsController(): IAdsPluginController {
     return new ImaAdsController(this);
   }
 

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -42,7 +42,7 @@ describe('Ima Plugin', function() {
       player.Event.AD_RESUMED,
       player.Event.AD_PAUSED,
       player.Event.AD_COMPLETED,
-      player.Event.ALL_ADS_COMPLETED,
+      player.Event.ADS_COMPLETED,
       player.Event.AD_BREAK_END,
       player.Event.AD_BREAK_START,
       player.Event.AD_FIRST_QUARTILE,
@@ -74,8 +74,8 @@ describe('Ima Plugin', function() {
     player.addEventListener(player.Event.AD_COMPLETED, () => {
       maybeDoneTest(adsEvents, player.Event.AD_COMPLETED, done);
     });
-    player.addEventListener(player.Event.ALL_ADS_COMPLETED, () => {
-      maybeDoneTest(adsEvents, player.Event.ALL_ADS_COMPLETED, done);
+    player.addEventListener(player.Event.ADS_COMPLETED, () => {
+      maybeDoneTest(adsEvents, player.Event.ADS_COMPLETED, done);
     });
     player.addEventListener(player.Event.AD_BREAK_START, () => {
       maybeDoneTest(adsEvents, player.Event.AD_BREAK_START, done);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@^0.46.1":
-  version "0.46.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.46.1.tgz#75109fefab7e8e9e28403ac75aa1c91de0063721"
-  integrity sha512-S1VWmjSwfZTTIan4V4Emf+kFy61hrJFo8Z73u/0kLe/9Dgx79nnvPKxjiclKmKXHi5dOkuiGc5JbfSrtgzYIdw==
+"@playkit-js/playkit-js@0.47.0-canary.173edfb":
+  version "0.47.0-canary.173edfb"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.47.0-canary.173edfb.tgz#de7dcea8d9d0f38e6764ab6c4d7b2b55a53cb209"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

* `IAdsPluginController` implementing (`active`, `done` getters)
* change `ALL_ADS_COMPLETED` to `ADS_COMPLETED` (for multiple ads plugins support)
* add `bumper` flag on ad
* do not show non-linear ad during bumper
* Wait for `AdsController` triggering to play the postroll 

Dependes on https://github.com/kaltura/playkit-js/pull/350

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
