### PR TITLE
fix(FEC-8936): VPAID ads may cause player crash

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -304,6 +304,7 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   this._setVideoEndedCallbackEnabled(true);
   this._setContentPlayheadTrackerEventsEnabled(true);
+  this._currentAd = null;
   if (!this._contentComplete) {
     this._hideAdsContainer();
     this._maybeSetVideoCurrentTime();

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -216,7 +216,9 @@ function onAdStarted(options: Object, adEvent: any): void {
  */
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  if (this._currentAd.isLinear()) {
+  if (this._currentAd === null) {
+    this.player.pause();
+  } else if (this._currentAd.isLinear()) {
     this._maybeIgnoreClickOnAd();
     if (this._stateMachine.is(State.PLAYING)) {
       this._adsManager.pause();

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -216,9 +216,7 @@ function onAdStarted(options: Object, adEvent: any): void {
  */
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  if (this._currentAd === null) {
-    this.player.pause();
-  } else if (this._currentAd.isLinear()) {
+  if (this._currentAd.isLinear()) {
     this._maybeIgnoreClickOnAd();
     if (this._stateMachine.is(State.PLAYING)) {
       this._adsManager.pause();
@@ -256,7 +254,6 @@ function onAdResumed(options: Object, adEvent: any): void {
  */
 function onAdCompleted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  this._currentAd = null;
   this.dispatchEvent(options.transition);
 }
 


### PR DESCRIPTION
### Description of the Changes

Relocated `currentAd` from from `onAdCompleted` to `onAdBreakEnd` in order to resolve the issue when ads are getting called complete when the adTag is still present.


### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
