### PR TITLE
fix(FEC-9013): [iOS] - Player doesnt play ads native when playsinline is false

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -55,7 +55,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   static defaultConfig: Object = {
     debug: false,
-    delayInitUntilSourceSelected: false,
+    delayInitUntilSourceSelected: true,
     disableMediaPreload: false,
     adsRenderingSettings: {
       restoreCustomPlaybackStateOnAdBreakComplete: true,

--- a/src/ima.js
+++ b/src/ima.js
@@ -55,7 +55,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   static defaultConfig: Object = {
     debug: false,
-    delayInitUntilSourceSelected: true,
+    delayInitUntilSourceSelected: false,
     disableMediaPreload: false,
     adsRenderingSettings: {
       restoreCustomPlaybackStateOnAdBreakComplete: true,
@@ -233,6 +233,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
     this._stateMachine = new ImaStateMachine(this);
+    this._setDefaultConfiguration(config);
     this._initMembers();
     this._init();
   }
@@ -452,6 +453,20 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.reset();
       }
     });
+  }
+
+  /**
+   * set default Configuration for plugin
+   * @private
+   * @returns {void}
+   * @instance
+   * @memberof Ima
+   * @param {Object} config - configuration of app for ima plugin
+   */
+  _setDefaultConfiguration(config: Object): void {
+    //check if delayInitUntilSourceSelected set in app configuration, else set true for ios
+    this.config.delayInitUntilSourceSelected =
+      typeof config.delayInitUntilSourceSelected === `boolean` ? this.config.delayInitUntilSourceSelected : this.player.env.os.name === 'iOS';
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -3,7 +3,7 @@ import {ImaMiddleware} from './ima-middleware';
 import {ImaAdsController} from './ima-ads-controller';
 import {ImaStateMachine} from './ima-state-machine';
 import {State} from './state';
-import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils} from '@playkit-js/playkit-js';
+import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils, Env} from '@playkit-js/playkit-js';
 import './assets/style.css';
 
 /**
@@ -55,7 +55,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   static defaultConfig: Object = {
     debug: false,
-    delayInitUntilSourceSelected: false,
+    delayInitUntilSourceSelected: Env.os.name === 'iOS',
     disableMediaPreload: false,
     adsRenderingSettings: {
       restoreCustomPlaybackStateOnAdBreakComplete: true,
@@ -233,7 +233,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
     this._stateMachine = new ImaStateMachine(this);
-    this._setDefaultConfiguration(config);
     this._initMembers();
     this._init();
   }
@@ -453,22 +452,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.reset();
       }
     });
-  }
-
-  /**
-   * set default Configuration for plugin
-   * @private
-   * @returns {void}
-   * @instance
-   * @memberof Ima
-   * @param {Object} config - configuration of app for ima plugin
-   */
-  _setDefaultConfiguration(config: Object): void {
-    //check if delayInitUntilSourceSelected set in app configuration, else set true for ios
-    //this.config contain the default configuration, config param doesnt, that's the reason why I used config
-    if (typeof config.delayInitUntilSourceSelected !== `boolean`) {
-      this.config.delayInitUntilSourceSelected = this.player.env.os.name === 'iOS';
-    }
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -465,8 +465,10 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _setDefaultConfiguration(config: Object): void {
     //check if delayInitUntilSourceSelected set in app configuration, else set true for ios
-    this.config.delayInitUntilSourceSelected =
-      typeof config.delayInitUntilSourceSelected === `boolean` ? this.config.delayInitUntilSourceSelected : this.player.env.os.name === 'iOS';
+    //this.config contain the default configuration, config param doesnt, that's the reason why I used config
+    if (typeof config.delayInitUntilSourceSelected !== `boolean`) {
+      this.config.delayInitUntilSourceSelected = this.player.env.os.name === 'iOS';
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

force delay until video tag will be loaded and then load the ima, ima ads take the inline configure from our video tag 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
