### PR TITLE
fix(FEC-9058): get state machine from kaltura with patch for LG TV

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "javascript-state-machine": "^3.0.1"
+    "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.0.1"
   },
   "devDependencies": {
     "@playkit-js/playkit-js": "^0.45.1-canary.4eaff16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4708,9 +4708,9 @@ istanbul@^0.4.0, istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-javascript-state-machine@^3.0.1:
+"javascript-state-machine@https://github.com/kaltura/javascript-state-machine.git#v3.0.1":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/javascript-state-machine/-/javascript-state-machine-3.0.1.tgz#327320336a20364e26b51d91662c14f14d41ea52"
+  resolved "https://github.com/kaltura/javascript-state-machine.git#e09614a51f2a64724bb151da6462bcb34fdb9883"
 
 jest-config@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION

### Description of the Changes

get state machine from kaltura, add patch for browser implementation error of shift function in LG TV browser.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
