### PR TITLE
fix(FEC-9111): seekbar doesn't work on WebOS

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -357,7 +357,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   isAdsPlayingOnSameVideoTag(): boolean {
     return (
-      !!this._adsManager && !!this._adsManager.isCustomPlaybackUsed() && !this._stateMachine.is(State.IDLE) && !this._stateMachine.is(State.DONE)
+      !!this._adsManager &&
+      !!this._adsManager.isCustomPlaybackUsed() &&
+      (this._stateMachine.is(State.PLAYING) || this._stateMachine.is(State.PENDING) || this._stateMachine.is(State.PAUSED))
     );
   }
 


### PR DESCRIPTION
### Description of the Changes

Issue: loadmetadata event doesnt get dispatched, which cause invisible seekbar.

solution: exclude loaded state from `isAdPlayingOnSameVideoTag` method - if ads didn't start or load yet then allow player events to be dispatched.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
