### PR TITLE
fix(FEC-9167): set default IMA lib protocol for non http protocols

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -584,7 +584,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _loadImaSDKLib(): Promise<*> {
-    const protocol = 'http:' === document.location.protocol ? '' : 'https:';
+    const protocolRegex = /^(https:|http:)/i.exec(document.location.protocol);
+    const protocol = protocolRegex && protocolRegex.hasOwnProperty('index') ? protocolRegex[protocolRegex.index] : 'https:';
     return this._isImaSDKLibLoaded()
       ? Promise.resolve()
       : Utils.Dom.loadScriptAsync(this.config.debug ? protocol + Ima.IMA_SDK_DEBUG_LIB_URL : protocol + Ima.IMA_SDK_LIB_URL);

--- a/src/ima.js
+++ b/src/ima.js
@@ -584,8 +584,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _loadImaSDKLib(): Promise<*> {
-    const protocolRegex = /^(https:|http:)/i.exec(document.location.protocol);
-    const protocol = protocolRegex && protocolRegex.hasOwnProperty('index') ? protocolRegex[protocolRegex.index] : 'https:';
+    const protocol = /^(https?:)/i.test(document.location.protocol) ? document.location.protocol : 'https:';
     return this._isImaSDKLibLoaded()
       ? Promise.resolve()
       : Utils.Dom.loadScriptAsync(this.config.debug ? protocol + Ima.IMA_SDK_DEBUG_LIB_URL : protocol + Ima.IMA_SDK_LIB_URL);

--- a/src/ima.js
+++ b/src/ima.js
@@ -584,7 +584,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _loadImaSDKLib(): Promise<*> {
-    const protocol = 'https:' === document.location.protocol ? '' : 'http:';
+    const protocol = 'http:' === document.location.protocol ? '' : 'https:';
     return this._isImaSDKLibLoaded()
       ? Promise.resolve()
       : Utils.Dom.loadScriptAsync(this.config.debug ? protocol + Ima.IMA_SDK_DEBUG_LIB_URL : protocol + Ima.IMA_SDK_LIB_URL);

--- a/src/ima.js
+++ b/src/ima.js
@@ -584,9 +584,10 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _loadImaSDKLib(): Promise<*> {
+    const protocol = 'https:' === document.location.protocol ? '' : 'http:';
     return this._isImaSDKLibLoaded()
       ? Promise.resolve()
-      : Utils.Dom.loadScriptAsync(this.config.debug ? Ima.IMA_SDK_DEBUG_LIB_URL : Ima.IMA_SDK_LIB_URL);
+      : Utils.Dom.loadScriptAsync(this.config.debug ? protocol + Ima.IMA_SDK_DEBUG_LIB_URL : protocol + Ima.IMA_SDK_LIB_URL);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Add default protocol https when our bundled application loaded with non valid protocol(not http or https).
Found on Samsung TV.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
