### PR TITLE
fix(FEC-9173): playback failed for unsupported ads.

### DIFF
--- a/src/ima-engine-decorator.js
+++ b/src/ima-engine-decorator.js
@@ -18,19 +18,21 @@ class ImaEngineDecorator extends BaseEngineDecorator {
 
   dispatchEvent(event: FakeEvent): boolean {
     if (!this._plugin.isAdOnSameVideoTag()) {
+      //after error ima doesn't on the same video tag
+      if (event.type === EventType.ERROR && this._plugin.isAdFailedOnSameVideoTag()) {
+        this._plugin.setAdFailedOnSameVideoTag(false);
+        this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
+        this._plugin.player.play();
+        return event.defaultPrevented;
+      } else if (event.type === EventType.AUTOPLAY_FAILED && this._plugin.isAdFailedOnSameVideoTag()) {
+        return event.defaultPrevented;
+      }
       return super.dispatchEvent(event);
     } else {
       if (this._plugin.isAdPlaying()) {
         return event.defaultPrevented;
-        //handle events for fatal adError that doesnt return the video source
-      } else if (event.type === EventType.ERROR && this._plugin.isAdFailedAndSourceChanged()) {
-        this._plugin.setAdFailed(false);
-        this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
-        this._plugin.player.play();
-        return event.defaultPrevented;
-      } else if (event.type === EventType.AUTOPLAY_FAILED && this._plugin.isAdFailedAndSourceChanged()) {
-        return event.defaultPrevented;
       }
+      //handle events for fatal adError that doesnt return the video source
       return super.dispatchEvent(event);
     }
   }

--- a/src/ima-engine-decorator.js
+++ b/src/ima-engine-decorator.js
@@ -17,16 +17,16 @@ class ImaEngineDecorator extends BaseEngineDecorator {
   }
 
   dispatchEvent(event: FakeEvent): boolean {
+    // after error ima doesn't on the same video tag
+    if (event.type === EventType.ERROR && this._plugin.isAdFailedOnSameVideoTag()) {
+      this._plugin.setAdFailedOnSameVideoTag(false);
+      this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
+      this._plugin.player.play();
+      return event.defaultPrevented;
+    } else if (event.type === EventType.AUTOPLAY_FAILED && this._plugin.isAdFailedOnSameVideoTag()) {
+      return event.defaultPrevented;
+    }
     if (!this._plugin.isAdOnSameVideoTag()) {
-      //after error ima doesn't on the same video tag
-      if (event.type === EventType.ERROR && this._plugin.isAdFailedOnSameVideoTag()) {
-        this._plugin.setAdFailedOnSameVideoTag(false);
-        this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
-        this._plugin.player.play();
-        return event.defaultPrevented;
-      } else if (event.type === EventType.AUTOPLAY_FAILED && this._plugin.isAdFailedOnSameVideoTag()) {
-        return event.defaultPrevented;
-      }
       return super.dispatchEvent(event);
     } else {
       if (this._plugin.isAdPlaying()) {

--- a/src/ima-engine-decorator.js
+++ b/src/ima-engine-decorator.js
@@ -1,5 +1,5 @@
 // @flow
-import {BaseEngineDecorator, FakeEvent, EventType} from '@playkit-js/playkit-js';
+import {BaseEngineDecorator, FakeEvent} from '@playkit-js/playkit-js';
 import {Ima} from './ima';
 
 /**
@@ -17,24 +17,7 @@ class ImaEngineDecorator extends BaseEngineDecorator {
   }
 
   dispatchEvent(event: FakeEvent): boolean {
-    // after error ima doesn't on the same video tag
-    //handle events for fatal adError that doesnt return the video source
-    if (event.type === EventType.ERROR && this._plugin.isAdFailedOnSameVideoTag()) {
-      this._plugin.setAdFailedOnSameVideoTag(false);
-      this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
-      this._plugin.player.play();
-      return event.defaultPrevented;
-    } else if (event.type === EventType.AUTOPLAY_FAILED && this._plugin.isAdFailedOnSameVideoTag()) {
-      return event.defaultPrevented;
-    }
-    if (!this._plugin.isAdOnSameVideoTag()) {
-      return super.dispatchEvent(event);
-    } else {
-      if (this._plugin.isAdPlaying()) {
-        return event.defaultPrevented;
-      }
-      return super.dispatchEvent(event);
-    }
+    return this._plugin.isAdOnSameVideoTag() && this._plugin.isAdPlaying() ? event.defaultPrevented : super.dispatchEvent(event);
   }
   /**
    * Get paused state.

--- a/src/ima-engine-decorator.js
+++ b/src/ima-engine-decorator.js
@@ -18,6 +18,7 @@ class ImaEngineDecorator extends BaseEngineDecorator {
 
   dispatchEvent(event: FakeEvent): boolean {
     // after error ima doesn't on the same video tag
+    //handle events for fatal adError that doesnt return the video source
     if (event.type === EventType.ERROR && this._plugin.isAdFailedOnSameVideoTag()) {
       this._plugin.setAdFailedOnSameVideoTag(false);
       this._plugin.player.getVideoElement().src = this._plugin.getContentSrc();
@@ -32,7 +33,6 @@ class ImaEngineDecorator extends BaseEngineDecorator {
       if (this._plugin.isAdPlaying()) {
         return event.defaultPrevented;
       }
-      //handle events for fatal adError that doesnt return the video source
       return super.dispatchEvent(event);
     }
   }

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -160,7 +160,7 @@ class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  this.setAdFailed(false);
+  this.setAdFailedOnSameVideoTag(false);
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
   if (this._adsManager.isCustomPlaybackUsed()) {
@@ -335,7 +335,9 @@ function onAdError(options: Object, adEvent: any): void {
   if (adEvent.type === 'adError') {
     this.logger.debug(adEvent.type.toUpperCase());
     let adError = adEvent.getError();
-    this.setAdFailed(true);
+    if (this._adsManager.isCustomPlaybackUsed()) {
+      this.setAdFailedOnSameVideoTag(true);
+    }
     //if this is autoplay or user already requested play then next promise will handle reset
     if (this._nextPromise) {
       this._nextPromise.reject(adError);

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -339,6 +339,7 @@ function onAdError(options: Object, adEvent: any): void {
       this.setAdFailedOnSameVideoTag(true);
     }
     //if this is autoplay or user already requested play then next promise will handle reset
+    //handle error for same video tag on decorator instead to avoid playback failed
     if (this._nextPromise && !this.isAdOnSameVideoTag()) {
       this._nextPromise.reject(adError);
     } else {

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -163,7 +163,7 @@ function onAdLoaded(options: Object, adEvent: any): void {
   this.setAdFailedOnSameVideoTag(false);
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
-  if (this._adsManager.isCustomPlaybackUsed()) {
+  if (this.isAdOnSameVideoTag()) {
     this.player.hideTextTrack();
   }
   const adBreakType = getAdBreakType(adEvent);
@@ -268,7 +268,7 @@ function onAdCompleted(options: Object, adEvent: any): void {
  */
 function onAdsCompleted(options: Object, adEvent: any): void {
   this.logger.debug(options.transition.toUpperCase());
-  if (this._adsManager.isCustomPlaybackUsed() && this._contentComplete) {
+  if (this.isAdOnSameVideoTag() && this._contentComplete) {
     this.player.getVideoElement().src = this._contentSrc;
   }
   onAdBreakEnd.call(this, options, adEvent);
@@ -335,11 +335,11 @@ function onAdError(options: Object, adEvent: any): void {
   if (adEvent.type === 'adError') {
     this.logger.debug(adEvent.type.toUpperCase());
     let adError = adEvent.getError();
-    if (this._adsManager.isCustomPlaybackUsed()) {
+    if (this.isAdOnSameVideoTag()) {
       this.setAdFailedOnSameVideoTag(true);
     }
     //if this is autoplay or user already requested play then next promise will handle reset
-    if (this._nextPromise && !this._adsManager.isCustomPlaybackUsed()) {
+    if (this._nextPromise && !this.isAdOnSameVideoTag()) {
       this._nextPromise.reject(adError);
     } else {
       this.reset();

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -339,7 +339,7 @@ function onAdError(options: Object, adEvent: any): void {
       this.setAdFailedOnSameVideoTag(true);
     }
     //if this is autoplay or user already requested play then next promise will handle reset
-    if (this._nextPromise) {
+    if (this._nextPromise && !this._adsManager.isCustomPlaybackUsed()) {
       this._nextPromise.reject(adError);
     } else {
       this.reset();

--- a/src/ima.js
+++ b/src/ima.js
@@ -164,12 +164,12 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _contentComplete: boolean;
   /**
-   * Flag to know when an ad failed.
+   * Flag to know when an ad failed on the same video tag.
    * @member
    * @private
    * @memberof Ima
    */
-  _isAdFailed: boolean;
+  _isAdFailedOnSameVideoTag: boolean;
   /**
    * Video current time before ads.
    * On custom playback when only one video tag playing, save the video current time.
@@ -384,8 +384,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @instance
    * @memberof Ima
    */
-  isAdFailedAndSourceChanged() {
-    return this._isAdFailed && this._contentSrc !== this.player.getVideoElement().src;
+  isAdFailedOnSameVideoTag() {
+    return this._isAdFailedOnSameVideoTag && this._contentSrc !== this.player.getVideoElement().src;
   }
 
   getContentTime(): number {
@@ -407,8 +407,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     return this._contentSrc || '';
   }
 
-  setAdFailed(status: boolean): void {
-    this._isAdFailed = status;
+  setAdFailedOnSameVideoTag(status: boolean): void {
+    this._isAdFailedOnSameVideoTag = status;
   }
   /**
    * Prepare the plugin before media is loaded.

--- a/src/ima.js
+++ b/src/ima.js
@@ -164,13 +164,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _contentComplete: boolean;
   /**
-   * Flag to know when an ad failed on the same video tag.
-   * @member
-   * @private
-   * @memberof Ima
-   */
-  _isAdFailedOnSameVideoTag: boolean;
-  /**
    * Video current time before ads.
    * On custom playback when only one video tag playing, save the video current time.
    * @member
@@ -377,17 +370,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     return this._stateMachine.is(State.PLAYING) || this._stateMachine.is(State.PENDING) || this._stateMachine.is(State.PAUSED);
   }
 
-  /**
-   * Gets the indicator if ads got an error on same video tag and source isn't equal to the original.
-   * @public
-   * @returns {boolean} - if ads got an error on same video tag and source isn't equal to the original.
-   * @instance
-   * @memberof Ima
-   */
-  isAdFailedOnSameVideoTag() {
-    return this._isAdFailedOnSameVideoTag && this._contentSrc !== this.player.getVideoElement().src;
-  }
-
   getContentTime(): number {
     let currentTime = 0;
     //current time exist for mid-roll otherwise it's pre-roll(start of video - 0) - post-roll(end of video)
@@ -405,10 +387,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
 
   getContentSrc(): string {
     return this._contentSrc || '';
-  }
-
-  setAdFailedOnSameVideoTag(status: boolean): void {
-    this._isAdFailedOnSameVideoTag = status;
   }
   /**
    * Prepare the plugin before media is loaded.

--- a/src/ima.js
+++ b/src/ima.js
@@ -506,7 +506,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _startAdsManager(): void {
     this.logger.debug('Start ads manager');
-    const readyPromise = this._adsManager.isCustomPlaybackUsed() && !this.config.disableMediaPreload ? this.player.ready() : Promise.resolve();
+    const readyPromise = this.isAdOnSameVideoTag() && !this.config.disableMediaPreload ? this.player.ready() : Promise.resolve();
     readyPromise.then(() => {
       this._adsManager.init(this.player.dimensions.width, this.player.dimensions.height, this._sdk.ViewMode.NORMAL);
       this._adsManager.start();
@@ -895,7 +895,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _maybeSaveVideoCurrentTime(): void {
-    if ((this._adsManager.isCustomPlaybackUsed() || this.config.forceReloadMediaAfterAds) && this.player.currentTime && this.player.currentTime > 0) {
+    if ((this.isAdOnSameVideoTag() || this.config.forceReloadMediaAfterAds) && this.player.currentTime && this.player.currentTime > 0) {
       this.logger.debug('Custom playback used: save current time before ads', this.player.currentTime);
       this._videoLastCurrentTime = this.player.currentTime;
     }
@@ -989,7 +989,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this.logger.debug('Ads manager loaded');
     const adsRenderingSettings = this._getAdsRenderingSetting();
     this._adsManager = adsManagerLoadedEvent.getAdsManager(this._contentPlayheadTracker, adsRenderingSettings);
-    this.config.forceReloadMediaAfterAds = this._adsManager.isCustomPlaybackUsed() ? false : this.config.forceReloadMediaAfterAds;
+    this.config.forceReloadMediaAfterAds = this.isAdOnSameVideoTag() ? false : this.config.forceReloadMediaAfterAds;
     const cuePoints = this._adsManager.getCuePoints();
     if (!cuePoints.length) {
       cuePoints.push(0);
@@ -1102,7 +1102,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _setToggleAdsCover(enable: boolean): void {
     if (enable) {
-      if (!this._adsManager.isCustomPlaybackUsed()) {
+      if (!this.isAdOnSameVideoTag()) {
         if (this._adsContainerDiv.parentNode) {
           this._adsContainerDiv.parentNode.insertBefore(this._adsCoverDiv, this._adsContainerDiv.nextSibling);
           this._isAdsCoverActive = true;
@@ -1207,7 +1207,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     //check if inBrowserFullscreen not set, just in case of inline true and not inBrowserFullscreen we will exit otherwise
     if (
       isIOS &&
-      !this._adsManager.isCustomPlaybackUsed() &&
+      !this.isAdOnSameVideoTag() &&
       (this.player.isFullscreen() && !this.player.config.playback.inBrowserFullscreen) &&
       this.player.config.playback.playsinline
     ) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -378,9 +378,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   }
 
   /**
-   * Gets the indicator if ads got an error and source isn't equal to the original.
+   * Gets the indicator if ads got an error on same video tag and source isn't equal to the original.
    * @public
-   * @returns {boolean} - if ads got an error and source isn't equal to the original.
+   * @returns {boolean} - if ads got an error on same video tag and source isn't equal to the original.
    * @instance
    * @memberof Ima
    */


### PR DESCRIPTION
### Description of the Changes

Playback will keep playing for hls.js and native when unsupported ads are playing on same video tag.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
