### PR TITLE
fix(FEC-9273): playing preroll on AV player (ios+playsinline=false) gets the player stuck

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -166,7 +166,7 @@ function onAdLoaded(options: Object, adEvent: any): void {
     this._selectedAudioTrack = this.player.getActiveTracks().audio;
     this._selectedTextTrack = this.player.getActiveTracks().text;
     this._selectedPlaybackRate = this.player.playbackRate;
-    // this.player.hideTextTrack();
+    this.player.hideTextTrack();
   }
   const adBreakType = getAdBreakType(adEvent);
   const adOptions = getAdOptions(adEvent);

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -166,7 +166,7 @@ function onAdLoaded(options: Object, adEvent: any): void {
     this._selectedAudioTrack = this.player.getActiveTracks().audio;
     this._selectedTextTrack = this.player.getActiveTracks().text;
     this._selectedPlaybackRate = this.player.playbackRate;
-    this.player.hideTextTrack();
+    // this.player.hideTextTrack();
   }
   const adBreakType = getAdBreakType(adEvent);
   const adOptions = getAdOptions(adEvent);
@@ -323,7 +323,7 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
     }
   }
   if (this.playOnMainVideoTag()) {
-    this.eventManager.listenOnce(this.player, this.player.Event.PLAYING, () => {
+    this.eventManager.listenOnce(this.player, this.player.Event.CAN_PLAY, () => {
       this.player.selectTrack(this._selectedAudioTrack);
       this.player.selectTrack(this._selectedTextTrack);
       this.player.playbackRate = this._selectedPlaybackRate;

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -163,6 +163,9 @@ function onAdLoaded(options: Object, adEvent: any): void {
   // When we are using the same video element on iOS, native captions still
   // appearing on the video element, so need to hide them before ad start.
   if (this.playOnMainVideoTag()) {
+    this._selectedAudioTrack = this.player.getActiveTracks().audio;
+    this._selectedTextTrack = this.player.getActiveTracks().text;
+    this._selectedPlaybackRate = this.player.playbackRate;
     this.player.hideTextTrack();
   }
   const adBreakType = getAdBreakType(adEvent);
@@ -318,6 +321,13 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
     } else if (!this.config.forceReloadMediaAfterAds) {
       this.player.play();
     }
+  }
+  if (this.playOnMainVideoTag()) {
+    this.eventManager.listenOnce(this.player, this.player.Event.PLAYING, () => {
+      this.player.selectTrack(this._selectedAudioTrack);
+      this.player.selectTrack(this._selectedTextTrack);
+      this.player.playbackRate = this._selectedPlaybackRate;
+    });
   }
   this.dispatchEvent(options.transition);
 }

--- a/src/ima.js
+++ b/src/ima.js
@@ -3,7 +3,7 @@ import {ImaMiddleware} from './ima-middleware';
 import {ImaAdsController} from './ima-ads-controller';
 import {ImaStateMachine} from './ima-state-machine';
 import {State} from './state';
-import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils, Env} from '@playkit-js/playkit-js';
+import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils, Env, AudioTrack, TextTrack} from '@playkit-js/playkit-js';
 import './assets/style.css';
 import {ImaEngineDecorator} from './ima-engine-decorator';
 
@@ -229,6 +229,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _isAdsCoverActive: boolean;
+  _selectedAudioTrack: ?AudioTrack;
+  _selectedTextTrack: ?TextTrack;
+  _selectedPlaybackRate: number;
 
   /**
    * Whether the ima plugin is valid.
@@ -553,6 +556,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._hasUserAction = false;
     this._togglePlayPauseOnAdsContainerCallback = null;
     this._contentDuration = null;
+    this._selectedAudioTrack = null;
+    this._selectedTextTrack = null;
+    this._selectedPlaybackRate = 1;
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -61,7 +61,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     disableMediaPreload: false,
     forceReloadMediaAfterAds: false,
     adsRenderingSettings: {
-      restoreCustomPlaybackStateOnAdBreakComplete: true,
+      restoreCustomPlaybackStateOnAdBreakComplete: false,
       enablePreloading: false,
       useStyledLinearAds: false,
       useStyledNonLinearAds: true,
@@ -525,6 +525,11 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       if (this._currentAd && !this._currentAd.isLinear()) {
         this._showAdsContainer();
       }
+    });
+    this.eventManager.listen(this.player, this.player.Event.MEDIA_LOADED, () => {
+      this._adsManager.updateAdsRenderingSettings({
+        restoreCustomPlaybackStateOnAdBreakComplete: !this.player.config.playback.playAdsWithMSE
+      });
     });
     this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._onMediaEnded());
   }
@@ -1001,9 +1006,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.logger.warn('unsupported adsRenderingSettings was set:', setting);
       }
     });
-    if (this.config.disableMediaPreload) {
-      adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = false;
-    }
+    adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = false;
     if (typeof this.config.adsRenderingSettings.playAdsAfterTime !== 'number') {
       adsRenderingSettings.playAdsAfterTime = this.player.config.playback.startTime;
     }


### PR DESCRIPTION
### Description of the Changes

* restore the playback source when ad break ended but only is the source exists  
* restore the selected tracks and rate when switching back to the playback

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
