### PR TITLE
fix(FEC-9160): captions displayed during midroll ad on AVplayer

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -166,6 +166,7 @@ function onAdLoaded(options: Object, adEvent: any): void {
     this._selectedAudioTrack = this.player.getActiveTracks().audio;
     this._selectedTextTrack = this.player.getActiveTracks().text;
     this._selectedPlaybackRate = this.player.playbackRate;
+    this._hideActiveTextTracksOnAVPlayer();
     this.player.hideTextTrack();
   }
   const adBreakType = getAdBreakType(adEvent);

--- a/src/ima.js
+++ b/src/ima.js
@@ -1195,11 +1195,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     const isIOS = this.player.env.os.name === 'iOS';
     if (isIOS && this.playOnMainVideoTag()) {
       let tracks = this.player.getVideoElement().textTracks;
-      if (tracks.length) {
-        for (let i = 0; i < tracks.length; i++) {
-          if (tracks[i].mode === 'showing') {
-            tracks[i].activeCues[0].position = 100;
-          }
+      for (let i = 0; i < tracks.length; i++) {
+        if (tracks[i].mode === 'showing') {
+          tracks[i].activeCues[0].position = 100;
         }
       }
     }

--- a/src/ima.js
+++ b/src/ima.js
@@ -1185,6 +1185,27 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   }
 
   /**
+   * On iOS AVPlayer caption stack on video tag, should re-position to hide
+   * @private
+   * @returns {void}
+   * @instance
+   * @memberof Ima
+   */
+  _hideActiveTextTracksOnAVPlayer(): void {
+    const isIOS = this.player.env.os.name === 'iOS';
+    if (isIOS) {
+      let tracks = this.player.getVideoElement().textTracks;
+      if (tracks.length) {
+        for (let i = 0; i < tracks.length; i++) {
+          if (tracks[i].mode === 'showing') {
+            tracks[i].activeCues[0].position = 100;
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * When playing with different video tags on iOS ads are not
    * supported in native full screen, so need to exist full screen before ads started.
    * @private

--- a/src/ima.js
+++ b/src/ima.js
@@ -1193,7 +1193,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   _hideActiveTextTracksOnAVPlayer(): void {
     const isIOS = this.player.env.os.name === 'iOS';
-    if (isIOS) {
+    if (isIOS && this.playOnMainVideoTag()) {
       let tracks = this.player.getVideoElement().textTracks;
       if (tracks.length) {
         for (let i = 0; i < tracks.length; i++) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -1197,7 +1197,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       let tracks = this.player.getVideoElement().textTracks;
       for (let i = 0; i < tracks.length; i++) {
         if (tracks[i].mode === 'showing') {
-          tracks[i].activeCues[0].position = 100;
+          for (let j = 0; j < tracks[i].activeCues; j++) {
+            tracks[i].activeCues[j].position = 100;
+          }
         }
       }
     }


### PR DESCRIPTION
### Description of the Changes

change position of activeCue remove the text tracks from ui

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
