### PR TITLE
fix(FEC-9367): unmate button doesn't change the ad volume

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -561,7 +561,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _addBindings(): void {
     FULL_SCREEN_EVENTS.forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, () => this._resizeAd()));
     this.eventManager.listen(this.player, 'resize', () => this._resizeAd());
-    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume());
+    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume(true));
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, event => {
       let selectedSource = event.payload.selectedSource;
@@ -1108,19 +1108,21 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.SKIPPABLE_STATE_CHANGED, adEvent => this._stateMachine.adcanskip(adEvent));
     this._adsManager.addEventListener(this._sdk.AdErrorEvent.Type.AD_ERROR, adEvent => this._stateMachine.aderror(adEvent));
   }
+
   /**
    * Syncs the player volume.
    * @private
+   * @param {boolean} muteChange - Whether to add or remove the ads cover.
    * @returns {void}
    * @instance
    * @memberof Ima
    */
-  _syncPlayerVolume(): void {
+  _syncPlayerVolume(muteChange: boolean = false): void {
     if (this._adsManager) {
       if (this.player.muted) {
         this._adsManager.setVolume(0);
       } else {
-        if (this._adsManager && typeof this.player.volume === 'number' && this.player.volume !== this._adsManager.getVolume()) {
+        if (this._adsManager && typeof this.player.volume === 'number' && (this.player.volume !== this._adsManager.getVolume() || muteChange)) {
           this._adsManager.setVolume(this.player.volume);
         }
       }

--- a/src/ima.js
+++ b/src/ima.js
@@ -1121,7 +1121,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       if (this.player.muted) {
         this._adsManager.setVolume(0);
       } else {
-        if (this._adsManager && this.player.volume && typeof this.player.volume === 'number') {
+        if (this._adsManager && !isNaN(this.player.volume) && typeof this.player.volume === 'number') {
           this._adsManager.setVolume(this.player.volume);
         }
       }

--- a/src/ima.js
+++ b/src/ima.js
@@ -1121,7 +1121,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       if (this.player.muted) {
         this._adsManager.setVolume(0);
       } else {
-        if (this._adsManager && typeof this.player.volume === 'number') {
+        if (this._adsManager && this.player.volume && typeof this.player.volume === 'number') {
           this._adsManager.setVolume(this.player.volume);
         }
       }

--- a/src/ima.js
+++ b/src/ima.js
@@ -561,7 +561,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _addBindings(): void {
     FULL_SCREEN_EVENTS.forEach(fullScreenEvent => this.eventManager.listen(document, fullScreenEvent, () => this._resizeAd()));
     this.eventManager.listen(this.player, 'resize', () => this._resizeAd());
-    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume(true));
+    this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => this._syncPlayerVolume());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, event => {
       let selectedSource = event.payload.selectedSource;
@@ -1112,17 +1112,16 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   /**
    * Syncs the player volume.
    * @private
-   * @param {boolean} muteChange - Whether to add or remove the ads cover.
    * @returns {void}
    * @instance
    * @memberof Ima
    */
-  _syncPlayerVolume(muteChange: boolean = false): void {
+  _syncPlayerVolume(): void {
     if (this._adsManager) {
       if (this.player.muted) {
         this._adsManager.setVolume(0);
       } else {
-        if (this._adsManager && typeof this.player.volume === 'number' && (this.player.volume !== this._adsManager.getVolume() || muteChange)) {
+        if (this._adsManager && typeof this.player.volume === 'number') {
           this._adsManager.setVolume(this.player.volume);
         }
       }


### PR DESCRIPTION
### Description of the Changes

ACT: IMA getVolume method response the same volume as was in player and we won't change the volume.
SOLUTION: always change the volume in IMA when player volume was changed

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
