### PR TITLE
fix(FEC-9429): new ad layout - stopped source will autoplay if AD_ERROR occurs on preroll URL

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -341,9 +341,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       this._adBreaksEventManager.listen(this._adsLoader, this._sdk.AdErrorEvent.Type.AD_ERROR, () => {
         playNext();
         if (this._podLength === 0) {
-          if (this.player.ads.isAdBreak()) {
-            this._stateMachine.adbreakend({type: this._sdk.AdEvent.Type.CONTENT_RESUME_REQUESTED});
-          }
+          this._stateMachine.adbreakend({type: this._sdk.AdEvent.Type.CONTENT_RESUME_REQUESTED});
           if (this._hasUserAction) {
             this._stateMachine.adscompleted({type: this._sdk.AdEvent.Type.ALL_ADS_COMPLETED});
           } else {

--- a/src/ima.js
+++ b/src/ima.js
@@ -341,10 +341,15 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       this._adBreaksEventManager.listen(this._adsLoader, this._sdk.AdErrorEvent.Type.AD_ERROR, () => {
         playNext();
         if (this._podLength === 0) {
-          this._stateMachine.adbreakend({type: this._sdk.AdEvent.Type.CONTENT_RESUME_REQUESTED});
-          this._stateMachine.adscompleted({type: this._sdk.AdEvent.Type.ALL_ADS_COMPLETED});
-          if (!this.player.ended) {
-            this.player.play();
+          if (this.player.ads.isAdBreak()) {
+            this._stateMachine.adbreakend({type: this._sdk.AdEvent.Type.CONTENT_RESUME_REQUESTED});
+          }
+          if (this._hasUserAction) {
+            this._stateMachine.adscompleted({type: this._sdk.AdEvent.Type.ALL_ADS_COMPLETED});
+          } else {
+            this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => {
+              this._stateMachine.adscompleted({type: this._sdk.AdEvent.Type.ALL_ADS_COMPLETED});
+            });
           }
         }
       });


### PR DESCRIPTION
### Description of the Changes

* Do not dispatch `ALL_ADS_COMPLETED` on error before the `FIRST_PLAY`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
