### PR TITLE
fix(FEC-9483): ad layout - no mid-roll ads play on iPad

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -98,7 +98,7 @@ class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_VOLUME_CHANGED,
-          from: [State.PLAYING, State.PAUSED, State.LOADED]
+          from: [State.PENDING, State.PLAYING, State.PAUSED, State.LOADED]
         },
         {
           name: context.player.Event.AD_MUTED,

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -198,6 +198,7 @@ function onAdLoaded(options: Object, adEvent: any): void {
 function onAdStarted(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   this._currentAd = adEvent.getAd();
+  this._adVideoTagAlreadyPlayed = true;
   this._resizeAd();
   this._maybeDisplayCompanionAds();
   if (!this._currentAd.isLinear()) {

--- a/src/ima.js
+++ b/src/ima.js
@@ -644,6 +644,16 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, () => this._onMediaTimeUpdate());
     this.eventManager.listen(this.player, this.player.Event.SEEKING, () => this._onMediaSeeking());
     this.eventManager.listen(this.player, this.player.Event.SEEKED, () => this._onMediaSeeked());
+    if (!this._playAdByConfig()) {
+      this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => {
+        this.loadPromise.then(() => this._adDisplayContainer.initialize());
+      });
+      this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => {
+        if (!this.player.ads.isAdBreak()) {
+          this.loadPromise.then(() => this._adDisplayContainer.initialize());
+        }
+      });
+    }
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -250,6 +250,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _adPosition: number;
   _firstOfAdPod: boolean;
   _waterfalled: boolean;
+  _adVideoTagAlreadyPlayed: boolean = false;
 
   /**
    * Whether the ima plugin is valid.
@@ -649,7 +650,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.loadPromise.then(() => this._adDisplayContainer.initialize());
       });
       this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => {
-        if (!this.isAdPlaying()) {
+        if (!this._adVideoTagAlreadyPlayed) {
           this.loadPromise.then(() => this._adDisplayContainer.initialize());
         }
       });

--- a/src/ima.js
+++ b/src/ima.js
@@ -649,7 +649,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         this.loadPromise.then(() => this._adDisplayContainer.initialize());
       });
       this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => {
-        if (!this.player.ads.isAdBreak()) {
+        if (!this.isAdPlaying()) {
           this.loadPromise.then(() => this._adDisplayContainer.initialize());
         }
       });

--- a/src/ima.js
+++ b/src/ima.js
@@ -646,12 +646,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this.eventManager.listen(this.player, this.player.Event.SEEKING, () => this._onMediaSeeking());
     this.eventManager.listen(this.player, this.player.Event.SEEKED, () => this._onMediaSeeked());
     if (!this._playAdByConfig()) {
-      this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => {
-        this.loadPromise.then(() => this._adDisplayContainer.initialize());
-      });
-      this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => {
+      this.eventManager.listenOnce(this.player, this.player.Event.USER_GESTURE, () => {
         if (!this._adVideoTagAlreadyPlayed) {
-          this.loadPromise.then(() => this._adDisplayContainer.initialize());
+          this._adDisplayContainer.initialize();
         }
       });
     }


### PR DESCRIPTION
### Description of the Changes

* **Issue:** no user gesture 
**Solution:** use the new `USER_GESTURE` event to initialize the ad video element (unless the ad video already played so it's unnecessary)
* Keep on `PENDING` when `AD_VOLUME_CHANGED` occuer while pending

Depends on https://github.com/kaltura/playkit-js/pull/415
Solves [FEC-9483](https://kaltura.atlassian.net/browse/FEC-9483)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
