### PR TITLE
feat(FEC-9470): ad layout - bumper support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.fbd1cb8",
+    "@playkit-js/playkit-js": "0.58.0-canary.7b17de0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -77,7 +77,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.fbd1cb8"
+    "@playkit-js/playkit-js": "0.58.0-canary.7b17de0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.b322bcb",
+    "@playkit-js/playkit-js": "0.58.0-canary.fbd1cb8",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -77,7 +77,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.b322bcb"
+    "@playkit-js/playkit-js": "0.58.0-canary.fbd1cb8"
   },
   "repository": {
     "type": "git",

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -544,7 +544,7 @@ function getAdOptions(adEvent: any): Object {
   adOptions.width = ad.isLinear() ? ad.getVastMediaWidth() : ad.getWidth();
   adOptions.height = ad.isLinear() ? ad.getVastMediaHeight() : ad.getHeight();
   adOptions.bitrate = ad.getVastMediaBitrate();
-  adOptions.bumper = podInfo.getIsBumper();
+  adOptions.bumper = podInfo.getIsBumper() || this._isBumper;
   return adOptions;
 }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -250,6 +250,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _adPosition: number;
   _firstOfAdPod: boolean;
   _waterfalled: boolean;
+  _isBumper: boolean;
   _adVideoTagAlreadyPlayed: boolean = false;
 
   /**
@@ -335,6 +336,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
 
   _playAd(adPod: PKAdPod): void {
     const ad = adPod[0];
+    this._isBumper = !!ad.bumper;
     const playNext = () => {
       adPod.shift();
       this._adBreaksEventManager.removeAll();
@@ -683,6 +685,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adPosition = 0;
     this._firstOfAdPod = false;
     this._waterfalled = false;
+    this._isBumper = false;
   }
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -336,7 +336,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
 
   _playAd(adPod: PKAdPod): void {
     const ad = adPod[0];
-    this._isBumper = !!ad.bumper;
     const playNext = () => {
       adPod.shift();
       this._adBreaksEventManager.removeAll();
@@ -392,6 +391,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
           }
         }
       });
+      this._isBumper = !!ad.bumper;
       this._requestAds(ad.url[0]);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@0.58.0-canary.fbd1cb8":
-  version "0.58.0-canary.fbd1cb8"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.58.0-canary.fbd1cb8.tgz#03bc5994ef91762f47067b381ffd2b7a212982a1"
+"@playkit-js/playkit-js@0.58.0-canary.7b17de0":
+  version "0.58.0-canary.7b17de0"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.58.0-canary.7b17de0.tgz#072cbd3a66970b9cd2090784a25654f4d2365663"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@0.58.0-canary.b322bcb":
-  version "0.58.0-canary.b322bcb"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.58.0-canary.b322bcb.tgz#09cedb8ff61235558559d39821a15fd40a6c8935"
+"@playkit-js/playkit-js@0.58.0-canary.fbd1cb8":
+  version "0.58.0-canary.fbd1cb8"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.58.0-canary.fbd1cb8.tgz#03bc5994ef91762f47067b381ffd2b7a212982a1"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

consider `ad.bumper` config
depends on https://github.com/kaltura/playkit-js/pull/420

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
