### PR TITLE
fix(FEC-9594): the playback failed after the pre-roll finished when "disableMediaPreload: true"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.7b17de0",
+    "@playkit-js/playkit-js": "0.59.2",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -77,7 +77,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.58.0-canary.7b17de0"
+    "@playkit-js/playkit-js": "0.59.2"
   },
   "repository": {
     "type": "git",

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -626,6 +626,72 @@ describe('Ima Plugin', function() {
     ima._playAdByConfig().should.be.false;
   });
 
+  it('Should load the content while the pre-roll playing', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[timestamp]'
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.LOAD_START, () => {
+      player.addEventListener(player.Event.AD_BREAK_END, () => {
+        done();
+      });
+    });
+    player.play();
+  });
+
+  it('Should load and play the content only once the pre-roll finished since disableMediaPreload is true', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl:
+        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[timestamp]',
+      disableMediaPreload: true
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_COMPLETED, () => {
+      player.addEventListener(player.Event.LOAD_START, () => {
+        player.addEventListener(player.Event.FIRST_PLAYING, () => {
+          done();
+        });
+      });
+    });
+    player.play();
+  });
+
+  it('Should load the content if the pre-roll load failed', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl: 'some/invalid/url'
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_ERROR, () => {
+      player.addEventListener(player.Event.LOAD_START, () => {
+        done();
+      });
+    });
+    player.load();
+  });
+
+  it('Should play the content if the pre-roll load failed', done => {
+    player = loadPlayerWithAds(targetId, {
+      adTagUrl: 'some/invalid/url'
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.AD_ERROR, () => {
+      player.addEventListener(player.Event.FIRST_PLAYING, () => {
+        done();
+      });
+    });
+    player.play();
+  });
+
+  it('Should load the content if no adTagUrl or adsResponse given', done => {
+    player = loadPlayerWithAds(targetId, {});
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.LOAD_START, () => {
+      done();
+    });
+    player.load();
+  });
+
   describe('playAdNow', function() {
     let sandbox;
     const vasts = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@0.58.0-canary.7b17de0":
-  version "0.58.0-canary.7b17de0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.58.0-canary.7b17de0.tgz#072cbd3a66970b9cd2090784a25654f4d2365663"
+"@playkit-js/playkit-js@0.59.2":
+  version "0.59.2"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.59.2.tgz#0e08b22cd8c99dd0d39594a223c632a17b3b3748"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

* Since https://github.com/kaltura/playkit-js/pull/431 need to load the next also when:
   `disableMediaPreload: true` ,`playOnMainVideoTag :true`
once the pre-roll finished or failed 
* update playkit to `0.59.2`

Solves FEC-9594

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
