### PR TITLE
fix(FEC-9629): Player is not inline when rendered after the DOM loads

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -879,9 +879,8 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       adsRequest.setAdWillPlayMuted(muted);
 
       const adWillAutoPlay = this.config.adWillAutoPlay;
-      const playerWillAutoPlay = Utils.Object.getPropertyPath(this.player.config, 'playback.autoplay');
-      const allowMutedAutoPlay = Utils.Object.getPropertyPath(this.player.config, 'playback.allowMutedAutoPlay');
-      const playsinline = Utils.Object.getPropertyPath(this.player.config, 'playback.playsinline');
+      const playerWillAutoPlay = this.player.config.playback.autoplay;
+      const allowMutedAutoPlay = this.player.config.playback.allowMutedAutoPlay;
 
       // Pass signal to IMA SDK if ad will autoplay with sound
       // First let application config this, otherwise if player is configured
@@ -890,7 +889,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         adsRequest.setAdWillAutoPlay(adWillAutoPlay);
         this._adsLoader.requestAds(adsRequest);
       } else if (playerWillAutoPlay) {
-        getCapabilities(EngineType.HTML5, playsinline).then(capabilities => {
+        getCapabilities(EngineType.HTML5).then(capabilities => {
           // If the plugin has been destroyed while calling this promise
           // the adsLoader will no longer exists
           if (!this._adsLoader) return;


### PR DESCRIPTION
### Description of the Changes

This reverts commit 37af209e as is unneeded any more due to https://github.com/kaltura/kaltura-player-js/pull/302

Solves FEC-9629

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
