### PR TITLE
fix(FEC-10251): floating player - no linear Ad isn't resized when moved to floating player

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -928,8 +928,15 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       if (this._currentAd.isLinear()) {
         this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
       } else {
-        this._alignAdsContainerSizeForOverlayAd();
-        this._adsManager.resize(this._currentAd.getWidth() + OVERLAY_AD_MARGIN, this._currentAd.getHeight() + OVERLAY_AD_MARGIN, viewMode);
+        const adTotalWidth = this._currentAd.getWidth() + OVERLAY_AD_MARGIN;
+        const adTotalHeight = this._currentAd.getHeight() + OVERLAY_AD_MARGIN;
+        if (adTotalWidth <= this.player.dimensions.width && adTotalHeight <= this.player.dimensions.height) {
+          this._alignAdsContainerSizeForOverlayAd();
+          this._adsManager.resize(this._currentAd.getWidth() + OVERLAY_AD_MARGIN, this._currentAd.getHeight() + OVERLAY_AD_MARGIN, viewMode);
+          this._showAdsContainer();
+        } else {
+          this._hideAdsContainer();
+        }
       }
     }
   }

--- a/src/ima.js
+++ b/src/ima.js
@@ -932,7 +932,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
         const adTotalHeight = this._currentAd.getHeight() + OVERLAY_AD_MARGIN;
         if (adTotalWidth <= this.player.dimensions.width && adTotalHeight <= this.player.dimensions.height) {
           this._alignAdsContainerSizeForOverlayAd();
-          this._adsManager.resize(this._currentAd.getWidth() + OVERLAY_AD_MARGIN, this._currentAd.getHeight() + OVERLAY_AD_MARGIN, viewMode);
+          this._adsManager.resize(adTotalWidth, adTotalHeight, viewMode);
           this._showAdsContainer();
         } else {
           this._hideAdsContainer();


### PR DESCRIPTION
### Description of the Changes

If trying to resize the ad in ima to a smaller size then an error is thrown from IMA.
Therefore we check in the resize wether the player dimensions is enough to show the ad if not we hide it.

solves FEC-10251

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
