### PR TITLE
fix(FEC-10335): text tracks doesn't show correctly on IOS same video tag

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -286,8 +286,7 @@ function onAdBreakStart(options: Object, adEvent: any): void {
   this.player.pause();
   const adBreakOptions = getAdBreakOptions.call(this, adEvent);
   const adBreak = new AdBreak(adBreakOptions);
-  this._maybeSaveTracksAndRate();
-  this._maybeHideTextTracks();
+  this._maybeSavePlayerSnapshot();
   this._maybeForceExitFullScreen();
   this._maybeSaveVideoCurrentTime();
   this.dispatchEvent(options.transition, {adBreak: adBreak});
@@ -320,14 +319,7 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
       this.player.play();
     }
   }
-  if (this.playOnMainVideoTag()) {
-    this.eventManager.listenOnce(this.player, this.player.Event.CAN_PLAY, () => {
-      this.player.selectTrack(this._selectedAudioTrack);
-      this.player.selectTrack(this._selectedTextTrack);
-      this.player.playbackRate = this._selectedPlaybackRate;
-      this._setActiveTextTracksOnAVPlayer();
-    });
-  }
+  this._maybeRestorePlayerSnapshot();
   this.dispatchEvent(options.transition);
 }
 

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -166,15 +166,6 @@ class ImaStateMachine {
  */
 function onAdLoaded(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
-  // When we are using the same video element on iOS, native captions still
-  // appearing on the video element, so need to hide them before ad start.
-  if (this.playOnMainVideoTag()) {
-    this._selectedAudioTrack = this.player.getActiveTracks().audio;
-    this._selectedTextTrack = this.player.getActiveTracks().text;
-    this._selectedPlaybackRate = this.player.playbackRate;
-    this._hideActiveTextTracksOnAVPlayer();
-    this.player.hideTextTrack();
-  }
   const adBreakType = getAdBreakType.call(this, adEvent);
   const adOptions = getAdOptions.call(this, adEvent);
   const ad = new Ad(adEvent.getAd().getAdId(), adOptions);
@@ -295,6 +286,15 @@ function onAdBreakStart(options: Object, adEvent: any): void {
   this.player.pause();
   const adBreakOptions = getAdBreakOptions.call(this, adEvent);
   const adBreak = new AdBreak(adBreakOptions);
+  // When we are using the same video element on iOS, native captions still
+  // appearing on the video element, so need to hide them before ad start.
+  if (this.playOnMainVideoTag()) {
+    this._selectedAudioTrack = this.player.getActiveTracks().audio;
+    this._selectedTextTrack = this.player.getActiveTracks().text;
+    this._selectedPlaybackRate = this.player.playbackRate;
+    this._hideActiveTextTracksOnAVPlayer();
+    this.player.hideTextTrack();
+  }
   this._maybeForceExitFullScreen();
   this._maybeSaveVideoCurrentTime();
   this.dispatchEvent(options.transition, {adBreak: adBreak});

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -286,15 +286,8 @@ function onAdBreakStart(options: Object, adEvent: any): void {
   this.player.pause();
   const adBreakOptions = getAdBreakOptions.call(this, adEvent);
   const adBreak = new AdBreak(adBreakOptions);
-  // When we are using the same video element on iOS, native captions still
-  // appearing on the video element, so need to hide them before ad start.
-  if (this.playOnMainVideoTag()) {
-    this._selectedAudioTrack = this.player.getActiveTracks().audio;
-    this._selectedTextTrack = this.player.getActiveTracks().text;
-    this._selectedPlaybackRate = this.player.playbackRate;
-    this._hideActiveTextTracksOnAVPlayer();
-    this.player.hideTextTrack();
-  }
+  this._maybeSaveTracksAndRate();
+  this._maybeHideTextTracks();
   this._maybeForceExitFullScreen();
   this._maybeSaveVideoCurrentTime();
   this.dispatchEvent(options.transition, {adBreak: adBreak});

--- a/src/ima.js
+++ b/src/ima.js
@@ -1351,7 +1351,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     if (this._textTracksHidden && isIOS && this.playOnMainVideoTag()) {
       let tracks = this.player.getVideoElement().textTracks;
       Array.from(tracks).forEach(track => {
-        if (track === 'showing') {
+        if (track.mode === 'showing') {
           Array.from(track.activeCues).forEach(cue => {
             if (this._textTracksHidden.length > 0) {
               cue.text = this._textTracksHidden.shift();

--- a/src/ima.js
+++ b/src/ima.js
@@ -1362,6 +1362,38 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     }
     this._textTracksHidden = [];
   }
+
+  /**
+   * When playing on same video tag need to keep the text track
+   * audio track and playback rate
+   * @private
+   * @returns {void}
+   * @instance
+   * @memberof Ima
+   */
+  _maybeSaveTracksAndRate(): void {
+    if (this.playOnMainVideoTag()) {
+      this._selectedAudioTrack = this.player.getActiveTracks().audio;
+      this._selectedTextTrack = this.player.getActiveTracks().text;
+      this._selectedPlaybackRate = this.player.playbackRate;
+    }
+  }
+
+  /**
+   * When we are using the same video element on iOS, native captions still
+   * appearing on the video element, so need to hide them before ad start.
+   * @private
+   * @returns {void}
+   * @instance
+   * @memberof Ima
+   */
+  _maybeHideTextTracks(): void {
+    if (this.playOnMainVideoTag()) {
+      this._hideActiveTextTracksOnAVPlayer();
+      this.player.hideTextTrack();
+    }
+  }
+
   /**
    * When playing with different video tags on iOS ads are not
    * supported in native full screen, so need to exist full screen before ads started.


### PR DESCRIPTION
### Description of the Changes

IMA probably changed their adloaded timing which causes issues on our logic with text tracks.
Issue: text tracks hide 5-6 sec before ad start, adloaded called 5-6 sec before which make this issue.
Solution: relocate the logic for text tracks to adbreakstart.

Solve FEC-10335.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
