### PR TITLE
fix(FEC-10730): High number of postrolls

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -874,7 +874,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       adsRequest.linearAdSlotHeight = this.player.dimensions.height;
       adsRequest.nonLinearAdSlotWidth = this.player.dimensions.width;
       adsRequest.nonLinearAdSlotHeight = this.player.dimensions.height / 3;
-      if (typeof this.player.config.sources.duration === 'number') {
+      if (this.getContentDuration() && !this.player.isLive) {
         adsRequest.contentDuration = this.getContentDuration();
       }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -872,6 +872,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       adsRequest.linearAdSlotHeight = this.player.dimensions.height;
       adsRequest.nonLinearAdSlotWidth = this.player.dimensions.width;
       adsRequest.nonLinearAdSlotHeight = this.player.dimensions.height / 3;
+      if (typeof this.player.config.sources.duration === 'number') {
+        adsRequest.contentDuration = this.getContentDuration();
+      }
 
       const muted = this.player.muted || this.player.volume === 0;
       adsRequest.setAdWillPlayMuted(muted);


### PR DESCRIPTION
### Description of the Changes

Because IMA doesn't know the video duration the post roll is loaded long before it is supposed to be played.
Solution suggested by google IMA is to send the duration in ad request.

solves FEC-10730

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
