### PR TITLE
fix(FEC-10837): unhandled error thrown by ima on playback ended after ad error

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -1058,7 +1058,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    */
   onPlaybackEnded(): Promise<void> {
     this.logger.debug('Playback ended');
-    this._adsLoader.contentComplete();
+    if (this._adsLoader) {
+      this._adsLoader.contentComplete();
+    }
     if (this._adsManager && this._adsManager.getCuePoints().includes(-1)) {
       return new Promise(resolve => {
         this.eventManager.listenOnce(this._adsManager, this._sdk.AdEvent.Type.ALL_ADS_COMPLETED, () => {


### PR DESCRIPTION
### Description of the Changes

Issue: adsLoader doesn't exist if an error occurs before the end(reset called).
Solution: add protection for adsLoader and call contentComplete only if it exists

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
