### PR TITLE
fix(FEC-10865): postroll is not playing when try to play pre-mid-post

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -1116,7 +1116,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     const adsRenderingSettings = this._getAdsRenderingSetting();
     this._adsManager = adsManagerLoadedEvent.getAdsManager(this._contentPlayheadTracker, adsRenderingSettings);
     this.config.forceReloadMediaAfterAds = this.playOnMainVideoTag() ? false : this.config.forceReloadMediaAfterAds;
-    const cuePoints = this._adsManager.getCuePoints();
+    const cuePoints = [...this._adsManager.getCuePoints()];
     if (!cuePoints.length) {
       cuePoints.push(0);
     }


### PR DESCRIPTION
### Description of the Changes

Issue: Youbora keeps the `e.payload.adBreakPosition` on `AD_MANIFEST_LOADED`, and changes it on `AD_PROGRESS` for internal use. This causes the ima's `cuePoints` to changed.
Solution: Passing a copy of the `cuePoints` on `AD_MANIFEST_LOADED` to keep it read-only

Solves FEC-10865

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
