### PR TITLE
fix(FEC-10983): manual companions does not work

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -1297,7 +1297,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _maybeDisplayCompanionAds(): void {
-    if (this.config.companions && this.config.companions.ads && !window.googletag) {
+    if (this.config.companions && this.config.companions.ads && !(window.googletag && window.googletag.cmd)) {
       const selectionCriteria = new this._sdk.CompanionAdSelectionSettings();
       selectionCriteria.resourceType = this._sdk.CompanionAdSelectionSettings.ResourceType.ALL;
       selectionCriteria.creativeType = this._sdk.CompanionAdSelectionSettings.CreativeType.ALL;


### PR DESCRIPTION
### Description of the Changes

`window.googletag` now exists despite it's manual companion, so add `window.googletag.cmd` to the condition 

Solves FEC-10983

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
