### PR TITLE
fix(FEC-10905): when move from ad to other ad there is a second when wrong time is shows

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -421,7 +421,8 @@ function onAdProgress(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   const remainingTime = this._adsManager.getRemainingTime();
   const duration = adEvent.getAdData() && adEvent.getAdData().duration;
-  const currentTime = duration - remainingTime;
+  let currentTime = duration - remainingTime;
+  currentTime = currentTime < 0 ? 0 : currentTime;
   if (Utils.Number.isNumber(duration) && Utils.Number.isNumber(currentTime)) {
     this.dispatchEvent(options.transition, {
       adProgress: {


### PR DESCRIPTION
### Description of the Changes

This is basically an IMA issue when the ads manager state is not synced with the AD_PROGRESS event data. On ads switching, when AD_PROGRESS event is raised, the remaining time of the ads manager referring to the new ad but the duration of the ad event referring to the previous ad.
Solution is to check if this calculation produce negative number and in this case set it to 0.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
