### PR TITLE
fix(FEC-11059): no replay button once ima postroll failed when midroll has skipped over

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -876,9 +876,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       adsRequest.linearAdSlotHeight = this.player.dimensions.height;
       adsRequest.nonLinearAdSlotWidth = this.player.dimensions.width;
       adsRequest.nonLinearAdSlotHeight = this.player.dimensions.height / 3;
-      if (this.getContentDuration() && !this.player.isLive()) {
-        adsRequest.contentDuration = this.getContentDuration();
-      }
+      adsRequest.contentDuration = -3;
 
       const muted = this.player.muted || this.player.volume === 0;
       adsRequest.setAdWillPlayMuted(muted);

--- a/src/ima.js
+++ b/src/ima.js
@@ -38,6 +38,13 @@ const ADS_CONTAINER_CLASS: string = 'playkit-ads-container';
  * @private
  */
 const ADS_COVER_CLASS: string = 'playkit-ads-cover';
+/**
+ * Flag for ima to not preload the postroll See https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/history (3.442.0 version)
+ * @type {number}
+ * @const
+ * @private
+ */
+const POSTROLL_PRELOAD_NONE: number = -3;
 
 /**
  * The ima plugin.
@@ -876,7 +883,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
       adsRequest.linearAdSlotHeight = this.player.dimensions.height;
       adsRequest.nonLinearAdSlotWidth = this.player.dimensions.width;
       adsRequest.nonLinearAdSlotHeight = this.player.dimensions.height / 3;
-      adsRequest.contentDuration = -3;
+      adsRequest.contentDuration = POSTROLL_PRELOAD_NONE;
 
       const muted = this.player.muted || this.player.volume === 0;
       adsRequest.setAdWillPlayMuted(muted);


### PR DESCRIPTION
### Description of the Changes

The issue is only when the post-roll preloaded, so prevent post-roll preloading 

Solves FEC-11059

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
