### PR TITLE
fix(FEC-11435): player not seeking to live edge after preroll ads

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -314,6 +314,11 @@ function onAdBreakEnd(options: Object, adEvent: any): void {
     }
     this._hideAdsContainer();
     this._maybeSetVideoCurrentTime();
+    const shouldPlayerSeekToLiveEdge =
+      this.player.isLive() && !this.config.disableMediaPreload && getAdBreakType.call(this, adEvent) === AdBreakType.PRE;
+    if (shouldPlayerSeekToLiveEdge) {
+      this.player.seekToLiveEdge();
+    }
     if (this._nextPromise) {
       this._resolveNextPromise();
     } else if (!this.config.forceReloadMediaAfterAds) {


### PR DESCRIPTION
### Description of the Changes

checking if player should seek to live edge after playing pre-roll ads, when streaming live.
Solves FEC-11435

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
