### PR TITLE
fix(FEC-10583): fix linear image ads

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,12 @@ const launchers = {
   }
 };
 
+const webpackConfig = require('./webpack.config.js');
+webpackConfig.module.rules.push({
+  test: /\.xml$/i,
+  use: 'raw-loader'
+});
+
 module.exports = function (config) {
   let karmaConf = {
     logLevel: config.LOG_INFO,
@@ -26,14 +32,21 @@ module.exports = function (config) {
     singleRun: true,
     colors: true,
     frameworks: ['mocha'],
-    files: ['test/setup/karma.js'],
+    files: [
+      'test/setup/karma.js',
+      {
+        pattern: 'test/setup/*.xml',
+        included: false,
+        served: true
+      }
+    ],
     preprocessors: {
       'src/**/*.js': ['webpack', 'sourcemap'],
       'test/setup/karma.js': ['webpack', 'sourcemap']
     },
     reporters: ['mocha', 'coverage'],
     webpack: {
-      ...require('./webpack.config.js'),
+      ...webpackConfig,
       externals: {}, //Need to remove externals otherwise they won't be included in test
       devtool: 'inline-source-map', // Need to define inline source maps when using karma
       mode: config.mode || 'development' // run in development mode by default to avoid minifying -> faster

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     ]
   },
   "dependencies": {
-    "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1"
+    "javascript-state-machine": "https://github.com/kaltura/javascript-state-machine.git#v3.1.0-k-1",
+    "raw-loader": "^4.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/ima.js
+++ b/src/ima.js
@@ -252,7 +252,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _isBumper: boolean;
   _isVpaid: boolean;
   _adVideoTagAlreadyPlayed: boolean = false;
-  _adBreakStarted: boolean = false;
   _adStartedEvent: any = null;
 
   /**

--- a/src/ima.js
+++ b/src/ima.js
@@ -1183,7 +1183,6 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.CONTENT_PAUSE_REQUESTED, adEvent => {
       if (this._playAdByConfig() || this._firstOfAdPod) {
         this._firstOfAdPod = false;
-        this._adBreakStarted = true;
         this._stateMachine.adbreakstart(adEvent);
 
         if (this._adStartedEvent) {
@@ -1205,7 +1204,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
     });
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.LOADED, adEvent => this._stateMachine.adloaded(adEvent));
     this._adsManager.addEventListener(this._sdk.AdEvent.Type.STARTED, adEvent => {
-      if (adEvent.getAd().isLinear() && !this._adBreakStarted) {
+      if (adEvent.getAd().isLinear() && !this.player.ads.isAdBreak()) {
         this._adStartedEvent = adEvent;
       } else {
         this._stateMachine.adstarted(adEvent);

--- a/test/setup/linear-image.vast.xml
+++ b/test/setup/linear-image.vast.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="4.0">
+  <Ad>
+    <InLine>
+      <AdSystem>AdSense</AdSystem>
+      <AdTitle>image</AdTitle>
+      <Description>
+        <![CDATA[image ad]]>
+      </Description>
+      <Creatives>
+        <Creative>
+          <UniversalAdId idRegistry="unknown" />
+          <NonLinearAds>
+            <TrackingEvents>
+            </TrackingEvents>
+            <NonLinear width="100" height="100" minSuggestedDuration="00:00:00" scalable="false" maintainAspectRatio="false">
+            </NonLinear>
+          </NonLinearAds>
+        </Creative>
+      </Creatives>
+      <Extensions>
+        <Extension type="AdSense">
+          <AttributionText>Ads by Google</AttributionText>
+          <UI>
+            <config>
+              <context data="default" />
+              <params>
+                <attribution_text data="Ads by Google" />
+                <enable_companion_banner bool="true" />
+                <signals int="25" />
+              </params>
+            </config>
+          </UI>
+        </Extension>
+      </Extensions>
+    </InLine>
+  </Ad>
+</VAST>

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -102,6 +102,36 @@ describe('Ima Plugin', function () {
     player.play();
   });
 
+  describe('ad events order', () => {
+    it('should fire AD_BREAK_STARTED before AD_STARTED - video ad', done => {
+      player = loadPlayerWithAds(targetId, {
+        adTagUrl:
+          'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]'
+      });
+      ima = player._pluginManager.get('ima');
+      player.addEventListener(player.Event.AD_BREAK_START, () => {
+        player.addEventListener(player.Event.AD_STARTED, () => {
+          done();
+        });
+      });
+      player.play();
+    });
+
+    it('should fire AD_BREAK_STARTED before AD_STARTED - linear image ad', done => {
+      const vastXML = require('../setup/linear-image.vast.xml').default;
+      player = loadPlayerWithAds(targetId, {
+        adsResponse: vastXML
+      });
+      ima = player._pluginManager.get('ima');
+      player.addEventListener(player.Event.AD_BREAK_START, () => {
+        player.addEventListener(player.Event.AD_STARTED, () => {
+          done();
+        });
+      });
+      player.play();
+    });
+  });
+
   it('should sent the ad data - linear', done => {
     player = loadPlayerWithAds(targetId, {
       adTagUrl:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,6 +1197,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json-schema@^7.0.8":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1456,10 +1461,25 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
   integrity sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==
 
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.5:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -7758,6 +7778,14 @@ raw-body@~1.1.0:
     bytes "1"
     string_decoder "0.10"
 
+raw-loader@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8347,6 +8375,15 @@ schema-utils@^2.6.5, schema-utils@^2.6.6:
     "@types/json-schema" "^7.0.4"
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
+
+schema-utils@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description of the Changes

In linear image (fullslot) ads, the SDK sends STARTED event before CONTENT_PAUSE_REQUESED, causing us to fire AD_STARTED before AD_BREAK_STARTED and breaking the ad ui. 
In case the event order is reversed, AD_STARTED will not fire until CONTENT_PAUSE_REQUESTED is recieved.
Fixes FEC-10583.

Related PR: https://github.com/kaltura/playkit-js-ui/pull/634

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
