### PR TITLE
fix(FEC-10583): IMA image ad is not functional

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -218,11 +218,13 @@ function onAdStarted(options: Object, adEvent: any): void {
 function onAdClicked(options: Object, adEvent: any): void {
   this.logger.debug(adEvent.type.toUpperCase());
   if (this._currentAd.isLinear()) {
-    this._maybeIgnoreClickOnAd();
-    if (this._stateMachine.is(State.PLAYING)) {
-      this._adsManager.pause();
+    if (this._isVideoAd()) {
+      this._maybeIgnoreClickOnAd();
+      if (this._stateMachine.is(State.PLAYING)) {
+        this._adsManager.pause();
+      }
+      this._setToggleAdsCover(true);
     }
-    this._setToggleAdsCover(true);
   } else {
     if (!this.player.paused) {
       this.player.pause();

--- a/src/ima.js
+++ b/src/ima.js
@@ -1466,6 +1466,10 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _playAdByConfig(): boolean {
     return !!(this.config.adTagUrl || this.config.adsResponse);
   }
+
+  _isVideoAd(): boolean {
+    return this._currentAd && this._currentAd.getContentType().startsWith('video');
+  }
 }
 
 export {Ima};


### PR DESCRIPTION
### Description of the Changes

When user clicks through a linear ad, only pause it if it's a video ad
Fixes FEC-10583

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
