### PR TITLE
fix(FEC-11757): V3: live with Ad: UI wrong state (Video is paused) after closing the new opened Ad tab

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -446,7 +446,6 @@ function onAdProgress(options: Object, adEvent: any): void {
  * @memberof ImaStateMachine
  */
 function onAdEvent(options: Object, adEvent: any): void {
-  console.error('444 onAdEvent', adEvent.type);
   this.logger.debug(adEvent.type.toUpperCase());
   this.dispatchEvent(options.transition);
 }

--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -220,8 +220,10 @@ function onAdClicked(options: Object, adEvent: any): void {
   if (this._currentAd.isLinear()) {
     if (this._isVideoAd()) {
       this._maybeIgnoreClickOnAd();
-      if (this._stateMachine.is(State.PLAYING)) {
+      if (this._stateMachine.is(State.PLAYING) && !this.player.isLive()) {
         this._adsManager.pause();
+      } else if (this.player.isLive()) {
+        this.resumeAd();
       }
       this._setToggleAdsCover(true);
     }
@@ -444,6 +446,7 @@ function onAdProgress(options: Object, adEvent: any): void {
  * @memberof ImaStateMachine
  */
 function onAdEvent(options: Object, adEvent: any): void {
+  console.error('444 onAdEvent', adEvent.type);
   this.logger.debug(adEvent.type.toUpperCase());
   this.dispatchEvent(options.transition);
 }


### PR DESCRIPTION
### Description of the Changes

**issue:**  ima launched the new “pause” behavior since April 16, 2021 look at  https://ads-developers.googleblog.com/2020/09/changes-to-pause-behavior-in.html 

**fix:**  resume the ad manually on live

solves: FEC-11757

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
