### PR TITLE
fix(FEC-12019): samsung - non linear ad - video does not start after clicking Play

### DIFF
--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -97,6 +97,11 @@ class ImaMiddleware extends BaseMiddleware {
           this._callNextLoad();
         }
       });
+      this._context.player.addEventListener(this._context.player.Event.AD_LOADED, event => {
+        if (!event.payload.ad.linear) {
+          this._callNextLoad();
+        }
+      });
     } else {
       this._callNextLoad();
     }

--- a/src/ima-middleware.js
+++ b/src/ima-middleware.js
@@ -80,7 +80,12 @@ class ImaMiddleware extends BaseMiddleware {
         this._adBreak = null;
         this._ad = null;
       });
-      this._context.player.addEventListener(this._context.player.Event.AD_LOADED, (event: FakeEvent) => (this._ad = event.payload.ad));
+      this._context.player.addEventListener(this._context.player.Event.AD_LOADED, (event: FakeEvent) => {
+        this._ad = event.payload.ad;
+        if (!this._ad.linear) {
+          this._callNextLoad();
+        }
+      });
       this._context.player.addEventListener(this._context.player.Event.AD_ERROR, () => {
         this._context.logger.debug('Ad error listener on middleware', this._adBreak, this._ad);
         // checking if the error raised for the last ad before playback:
@@ -94,11 +99,6 @@ class ImaMiddleware extends BaseMiddleware {
       });
       this._context.player.addEventListener(this._context.player.Event.AD_MANIFEST_LOADED, event => {
         if (!event.payload.adBreaksPosition.includes(0)) {
-          this._callNextLoad();
-        }
-      });
-      this._context.player.addEventListener(this._context.player.Event.AD_LOADED, event => {
-        if (!event.payload.ad.linear) {
           this._callNextLoad();
         }
       });

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -795,6 +795,19 @@ describe('Ima Plugin', function () {
     player.play();
   });
 
+  it('should call to player load when non-linear and disableMediaPreload', done => {
+    player = loadPlayerWithAds(targetId, {
+      disableMediaPreload: true,
+      adTagUrl:
+        '//pubads.g.doubleclick.net/gampad/ads?sz=480x70&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinear&correlator='
+    });
+    ima = player._pluginManager.get('ima');
+    player.addEventListener(player.Event.MEDIA_LOADED, () => {
+      done();
+    });
+    player.play();
+  });
+
   describe('playAdNow', function () {
     let sandbox;
     const vasts = [


### PR DESCRIPTION
### Description of the Changes

call to next load if it's non-linear ad

Solves FEC-12019

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
