### PR TITLE
fix(FEC-12236,FEC-FEC-12237): VPAID ads part of the AD is cut

### DIFF
--- a/src/ima-state-machine.js
+++ b/src/ima-state-machine.js
@@ -60,7 +60,7 @@ class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_BREAK_END,
-          from: [State.IDLE, State.PLAYING, State.LOADED, State.PAUSED],
+          from: [State.IDLE, State.PLAYING, State.LOADED, State.PAUSED, State.PENDING],
           to: State.IDLE
         },
         {
@@ -116,7 +116,7 @@ class ImaStateMachine {
         },
         {
           name: context.player.Event.AD_PROGRESS,
-          from: [State.PLAYING, State.PAUSED, State.PENDING]
+          from: [State.PLAYING, State.PAUSED, State.PENDING, State.IDLE]
         },
         {
           name: context.player.Event.AD_BUFFERING,

--- a/src/ima.js
+++ b/src/ima.js
@@ -944,7 +944,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _resizeAd() {
     if (this._sdk && this._adsManager && this._currentAd) {
       let viewMode = this.player.isFullscreen() ? this._sdk.ViewMode.FULLSCREEN : this._sdk.ViewMode.NORMAL;
-      if (this._currentAd.isLinear()) {
+      if (this._currentAd.isLinear() || this._isVpaid) {
         this._adsManager.resize(this.player.dimensions.width, this.player.dimensions.height, viewMode);
       } else {
         const adTotalWidth = this._currentAd.getWidth() + OVERLAY_AD_MARGIN;

--- a/test/src/ima.spec.js
+++ b/test/src/ima.spec.js
@@ -761,10 +761,10 @@ describe('Ima Plugin', function () {
     player.load();
   });
 
-  it.skip('should sent vpaid true - linear', done => {
+  it('should sent vpaid true - linear', done => {
     player = loadPlayerWithAds(targetId, {
       adTagUrl:
-        '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator='
+        '//pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinearvpaid2js&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator='
     });
     ima = player._pluginManager.get('ima');
     player.addEventListener(player.Event.AD_STARTED, e => {


### PR DESCRIPTION
### Description of the Changes

for vpaid keep the playkit-ads element dimensions like the player dimensions since ima calculates the vpaid position based on it. 
this change causes the player overlay to be unclickable when non-linear vpaid is displayed.
only the center playback controls get z-index to let the user pause/play the player during the non-linear vpaid is displayed on small screen - see https://github.com/kaltura/playkit-js-ui/pull/677

also, add missing states for non-linear vpaid

Solves FEC-12236, FEC-12237

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
