### PR TITLE
fix(FEC-12067): [TV Samsung] - Video restart from beginning after Mid-Roll

### DIFF
--- a/src/ima.js
+++ b/src/ima.js
@@ -253,6 +253,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
   _isVpaid: boolean;
   _adVideoTagAlreadyPlayed: boolean = false;
   _adStartedEvent: any = null;
+  _engine: any = null;
 
   /**
    * Whether the ima plugin is valid.
@@ -281,6 +282,7 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   getEngineDecorator(engine: IEngine): IEngineDecorator {
+    this._engine = engine;
     return new ImaEngineDecorator(engine, this);
   }
 
@@ -1029,10 +1031,9 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _maybeSaveVideoCurrentTime(): void {
-    const currentTime = this.player.getVideoElement().currentTime;
-    if ((this.playOnMainVideoTag() || this.config.forceReloadMediaAfterAds) && currentTime > 0) {
-      this.logger.debug('Custom playback used: save current time before ads', currentTime);
-      this._videoLastCurrentTime = currentTime;
+    if ((this.playOnMainVideoTag() || this.config.forceReloadMediaAfterAds) && this._engine.currentTime > 0) {
+      this.logger.debug('Custom playback used: save current time before ads', this._engine.currentTime);
+      this._videoLastCurrentTime = this._engine.currentTime;
     }
   }
 

--- a/src/ima.js
+++ b/src/ima.js
@@ -1029,9 +1029,10 @@ class Ima extends BasePlugin implements IMiddlewareProvider, IAdsControllerProvi
    * @memberof Ima
    */
   _maybeSaveVideoCurrentTime(): void {
-    if ((this.playOnMainVideoTag() || this.config.forceReloadMediaAfterAds) && this.player.currentTime && this.player.currentTime > 0) {
-      this.logger.debug('Custom playback used: save current time before ads', this.player.currentTime);
-      this._videoLastCurrentTime = this.player.currentTime;
+    const currentTime = this.player.getVideoElement().currentTime;
+    if ((this.playOnMainVideoTag() || this.config.forceReloadMediaAfterAds) && currentTime > 0) {
+      this.logger.debug('Custom playback used: save current time before ads', currentTime);
+      this._videoLastCurrentTime = currentTime;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

On smart tv, the currentTime was being taken from the engine decorator instead of from the video element, and it was always zero, so we never saved the actual time before starting the mid-roll ad. Taking the time from the video element fixes the issue.

Resolves FEC-12067

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
